### PR TITLE
Try harder to to preserve newlines while copying in the Desktop app

### DIFF
--- a/app/scripts/views/fields/field-view.js
+++ b/app/scripts/views/fields/field-view.js
@@ -85,7 +85,7 @@ var FieldView = Backbone.View.extend({
         range.selectNodeContents(this.valueEl[0]);
         selection.removeAllRanges();
         selection.addRange(range);
-        copyRes = CopyPaste.copy(this.valueEl.text());
+        copyRes = CopyPaste.copy(this.valueEl[0].innerText || this.valueEl.text());
         if (copyRes) {
             selection.removeAllRanges();
             this.trigger('copy', { source: this, copyRes: copyRes });


### PR DESCRIPTION
Clicking a field's label to copy it's value is a super-convenient feature.  In the browser, this works flawlessly, even for values with more than one line.  In the desktop client, however, copying a multi-line field in this way will copy the field's value, but with all of the lines concatenated.  In other words, if a field's value was:

```
one
two
three
```

Clicking on the field's name would copy the text above if Keeweb is loaded up in a browser, but when it's run as an Electron app, the following is copied:

```
onetwothree
```

Although it's a non-standard property of DOM `Node`s, the `innerText` property is documented as preserving newlines.

BTW, I was going to submit the PR against `master`, but I get build errors against that branch...the `develop` branch builds fine :).  Guess this'll have to wait until the next release.