### PR TITLE
Updated ISSUE_TEMPLATE: point antelle -> keeweb org

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 Thanks for taking the time to contribute!
 
-Please, read https://github.com/antelle/keeweb/wiki/FAQ before submitting a new issue and fill in the following (if applicable):
+Please, read https://github.com/keeweb/keeweb/wiki/FAQ before submitting a new issue and fill in the following (if applicable):
 
 - what were your actions?
 - what was wrong?


### PR DESCRIPTION
The template wasn't updated to point to the new Github org, so following the link wouldn't work anymore when people submit images.