### PR TITLE
Wordage change

### DIFF
--- a/app/scripts/util/locale.js
+++ b/app/scripts/util/locale.js
@@ -64,7 +64,7 @@ var Locale = {
     genPresetDefault: 'default preset',
     genPresetDerived: 'like old password',
     genPresetPronounceable: 'pronounceable',
-    genPresetMed: 'medium length',
+    genPresetMed: 'medium',
     genPresetLong: 'long',
     genPresetPin4: '4-digit PIN',
     genPresetMac: 'MAC address',


### PR DESCRIPTION
In password generator, change 'medium length' -> 'medium'.

This makes it consistant between 'medium' and 'long', and I thought just 'medium' and 'long' looked better than 'medium length' and 'long length'. (Fairly clear from the context)
