### PR TITLE
Fix #279: Auto-type with special characters on Mac

### DIFF
--- a/app/scripts/auto-type/emitter/auto-type-emitter-darwin.js
+++ b/app/scripts/auto-type/emitter/auto-type-emitter-darwin.js
@@ -65,9 +65,11 @@ AutoTypeEmitter.prototype.key = function(key) {
 };
 
 AutoTypeEmitter.prototype.copyPaste = function(text) {
+    this.pendingScript.push('delay 0.5');
     this.pendingScript.push('set the clipboard to "' + this.escape(text) + '"');
+    this.pendingScript.push('delay 0.5');
     this.pendingScript.push('keystroke "v" using command down');
-    this.pendingScript.push('delay 0.05');
+    this.pendingScript.push('delay 0.5');
     this.callback();
 };
 

--- a/app/scripts/auto-type/emitter/auto-type-emitter-darwin.js
+++ b/app/scripts/auto-type/emitter/auto-type-emitter-darwin.js
@@ -36,10 +36,21 @@ AutoTypeEmitter.prototype.setMod = function(mod, enabled) {
     }
 };
 
+AutoTypeEmitter.prototype.isAlphaNumeric = function(text) {
+    return !(/[^a-zA-Z0-9]/.test(text));
+};
+
+AutoTypeEmitter.prototype.escape = function(text) {
+    return text.replace(/"/g, '\\"').replace(/\\/g, '\\\\');
+};
+
 AutoTypeEmitter.prototype.text = function(text) {
-    text = text.replace(/"/g, '\\"').replace(/\\/g, '\\\\');
-    this.pendingScript.push('keystroke "' + text + '"' + this.modString());
-    this.callback();
+    if (this.isAlphaNumeric(text)) {
+        this.pendingScript.push('keystroke "' + this.escape(text) + '"' + this.modString());
+        this.callback();
+    } else {
+        this.copyPaste(text);
+    }
 };
 
 AutoTypeEmitter.prototype.key = function(key) {
@@ -54,11 +65,9 @@ AutoTypeEmitter.prototype.key = function(key) {
 };
 
 AutoTypeEmitter.prototype.copyPaste = function(text) {
-    this.pendingScript.push('delay 0.5');
-    this.pendingScript.push('set the clipboard to "' + text.replace(/"/g, '\\"') + '"');
-    this.pendingScript.push('delay 0.5');
+    this.pendingScript.push('set the clipboard to "' + this.escape(text) + '"');
     this.pendingScript.push('keystroke "v" using command down');
-    this.pendingScript.push('delay 0.5');
+    this.pendingScript.push('delay 0.05');
     this.callback();
 };
 


### PR DESCRIPTION
- Using copy-and-paste for special characters so it works on any Mac
  Input Source
- See http://stackoverflow.com/q/38484431/2654518
- Current delay of total 1.5 seconds per copy-and-paste makes
   auto-type considerably slow
- It could be faster if there was no splitting of characters in
  auto-type-runner.js getEntryFieldsKeys() when value.isProtected