### PR TITLE
Fix favicons and images from being stretched horizontally

### DIFF
--- a/app/styles/areas/_list.scss
+++ b/app/styles/areas/_list.scss
@@ -132,7 +132,8 @@
     }
 
     &-icon {
-      width: 16px;
+      margin-right: 2px;
+      width: 14px;
       height: 14px;
       &--custom {
         vertical-align: text-bottom;


### PR DESCRIPTION
When downloading favicons or setting custom icons, they were 2px too wide.

**Before:**
![before](https://cloud.githubusercontent.com/assets/144865/17412152/7cc87b68-5a7b-11e6-9d79-204dfb8d4af9.png)

**Now:**
![after](https://cloud.githubusercontent.com/assets/144865/17412154/80a27b12-5a7b-11e6-9efe-69ef2d1c7bd7.png)

