### PR TITLE
Present all obfuscated passwords with the same length.

### DIFF
--- a/app/scripts/util/password-generator.js
+++ b/app/scripts/util/password-generator.js
@@ -110,7 +110,7 @@ var PasswordGenerator = {
     },
 
     present: function(length) {
-        return new Array(length + 1).join('•');
+        return '• • • • •';
     }
 };
 


### PR DESCRIPTION
This would prevent someone looking over your shoulder and guessing the length of your password. A slight improvement in security through obscurity for the the uninitiated hacker.