### PR TITLE
Fixed WebDav save destination

### DIFF
--- a/app/scripts/storage/storage-webdav.js
+++ b/app/scripts/storage/storage-webdav.js
@@ -86,7 +86,11 @@ var StorageWebDav = StorageBase.extend({
                     }
                     var movePath = path;
                     if (movePath.indexOf('://') < 0) {
-                        movePath = location.href.replace(/[^/]*$/, movePath);
+                        if (movePath.indexOf('/') === 0) {
+                            movePath = location.protocol + '//' + location.host + movePath;
+                        } else {
+                            movePath = location.href.replace(/\?(.*)/, '').replace(/[^/]*$/, movePath);
+                        }
                     }
                     that._request(_.defaults({
                         op: 'Save:move', method: 'MOVE', path: tmpPath, nostat: true,


### PR DESCRIPTION
Modified WebDav save move destination to work correctly with relative and root paths, removing any URL parameters to prevent replacing the wrong /, fixes #435 