### PR TITLE
KeeWeb helper not found

### DIFF
--- a/app/scripts/comp/launcher-electron.js
+++ b/app/scripts/comp/launcher-electron.js
@@ -76,7 +76,7 @@ const Launcher = {
         this.req('fs').stat(path, (err, stats) => callback(stats, err));
     },
     statFileSync: function(path) {
-        this.req('fs').statSync(path);
+        return this.req('fs').statSync(path);
     },
     mkdir: function(dir, callback) {
         const fs = this.req('fs');


### PR DESCRIPTION
I was getting an error when running the project through electron:

> Error Helper not found. Searched paths: ... (error stems from auto-type-native-helper.js)

I believe the issue is caused by the call to Launcher.statFileSync(possiblePath) on line 22. Looking at the method implementation (in launcher-electron.js, line 78), it returns undefined, yet AutoTypeNativeHelper tries to get a ctime property from it.