### PR TITLE
Add ability to sort by expired entries

### DIFF
--- a/app/scripts/collections/entry-collection.js
+++ b/app/scripts/collections/entry-collection.js
@@ -19,7 +19,9 @@ const EntryCollection = Backbone.Collection.extend({
         '-created': Comparators.dateComparator('created', false),
         'updated': Comparators.dateComparator('updated', true),
         '-updated': Comparators.dateComparator('updated', false),
-        '-attachments': function(x, y) { return this.attachmentSortVal(x).localeCompare(this.attachmentSortVal(y)); }
+        '-attachments': function(x, y) { return this.attachmentSortVal(x).localeCompare(this.attachmentSortVal(y)); },
+        'expired': Comparators.boolComparator('expired', true),
+        '-expired': Comparators.boolComparator('expired', false)
     },
 
     defaultComparator: 'title',

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -135,6 +135,8 @@
   "searchAttachments": "Attachments",
   "searchAZ": "A {} Z",
   "searchZA": "Z {} A",
+  "searchFT": "False {} True",
+  "searchTF": "True {} False",
   "searchON": "Old {} New",
   "searchNO": "New {} Old",
   "searchShiftClickOr": "shift-click or",
@@ -145,6 +147,8 @@
   "searchOptions": "Options",
   "searchCase": "Match case",
   "searchRegex": "RegEx",
+  "searchExpires": "Expires",
+  "searchExpired": "Expired",
 
   "openOpen": "Open",
   "openNew": "New",

--- a/app/scripts/util/comparators.js
+++ b/app/scripts/util/comparators.js
@@ -19,6 +19,14 @@ const Comparators = {
         } else {
             return function (x, y) { return y[field] - x[field]; };
         }
+    },
+
+    boolComparator: function(field, asc) {
+        if (asc) {
+            return function (x, y) { return (x[field] ? 1 : 0) - (y[field] ? 1 : 0); };
+        } else {
+            return function (x, y) { return (y[field] ? 1 : 0) - (x[field] ? 1 : 0); };
+        }
     }
 };
 

--- a/app/scripts/views/list-search-view.js
+++ b/app/scripts/views/list-search-view.js
@@ -43,7 +43,9 @@ const ListSearchView = Backbone.View.extend({
             { value: '-created', icon: 'sort-numeric-desc', loc: () => Locale.searchCreated + ' ' + this.addArrow(Locale.searchNO) },
             { value: 'updated', icon: 'sort-numeric-asc', loc: () => Locale.searchUpdated + ' ' + this.addArrow(Locale.searchON) },
             { value: '-updated', icon: 'sort-numeric-desc', loc: () => Locale.searchUpdated + ' ' + this.addArrow(Locale.searchNO) },
-            { value: '-attachments', icon: 'sort-amount-desc', loc: () => Locale.searchAttachments }
+            { value: '-attachments', icon: 'sort-amount-desc', loc: () => Locale.searchAttachments },
+            { value: 'expired', icon: 'sort-amount-desc', loc: () => Locale.searchExpired + ' ' + this.addArrow(Locale.searchFT) },
+            { value: '-expired', icon: 'sort-amount-desc', loc: () => Locale.searchExpired + ' ' + this.addArrow(Locale.searchTF) }
         ];
         this.sortIcons = {};
         this.sortOptions.forEach(function(opt) {


### PR DESCRIPTION
This PR introduces the ability to sort by expired entries via the sort dropdown. I find this helpfull when attempting to find my expired entries. I searched in the issues and noticed that [1] kinda touches in here, but, rather than display expired entries on startup, you can simply sort then later or while searching. In [1] I also noticed there was talk about an Audit log, I'm not sure if this feature is needed, if an audit log is upcoming, but I still see this feature helpful.

1: #223 

