### PR TITLE
Add rel=noreferrer to links in the URL field

### DIFF
--- a/app/scripts/views/fields/field-view-url.js
+++ b/app/scripts/views/fields/field-view-url.js
@@ -4,7 +4,7 @@ const FieldViewUrl = FieldViewText.extend({
     displayUrlRegex: /^http:\/\//i,
 
     renderValue: function(value) {
-        return value ? '<a href="' + _.escape(this.fixUrl(value)) + '" target="_blank">' + _.escape(this.displayUrl(value)) + '</a>' : '';
+        return value ? '<a href="' + _.escape(this.fixUrl(value)) + '" rel="noreferrer" target="_blank">' + _.escape(this.displayUrl(value)) + '</a>' : '';
     },
 
     fixUrl: function(url) {


### PR DESCRIPTION
When opened from the webapp, a malicious target page could trigger navigation in the KeeWeb's tab using `window.opener`.

The proper way to fix this would be using `rel=noopener`, but unfortunately even the latest versions of IE do not support it. At the same time `rel=noreferrer`, for historical reasons, implies `rel=noopener` when used with `target=blank` and is supported by IE11 (in later versions of Windows 10) and Edge.

More details and examples of the attack at [Mathias Bynens' website](https://mathiasbynens.github.io/rel-noopener/).

----

A risk with this `window.opener` issue is really low, but I see no reason not to have a basic protection against it, so here we are. 🙂 

It's kind of a fix, not a feature, so based on `master`, but being this small it applies cleanly to `develop` too.