### PR TITLE
implement Docker support on raspberry pi

### DIFF
--- a/package/docker-rpi/Dockerfile
+++ b/package/docker-rpi/Dockerfile
@@ -1,0 +1,58 @@
+# KeeWeb official docker container
+# https://keeweb.info
+# (C) Antelle 2017, MIT license https://github.com/keeweb/keeweb
+# Based on nginx-ssl-secure https://github.com/MarvAmBass/docker-nginx-ssl-secure/
+
+# Building locally:
+# docker build -t keeweb .
+# docker run --name keeweb -d -p 443:443 -p 80:80 -e 'DH_SIZE=512' -v $EXT_DIR:/etc/nginx/external/ keeweb
+
+# Using pre-built image from dockerhub:
+# If you have SSL certs, put your dh.pem, cert.pem, key.pem to /etc/nginx/external/ and run with:
+# docker run --name keeweb -d -p 443:443 -p 80:80 -v $EXT_DIR:/etc/nginx/external/ antelle/keeweb
+# Or, to generate self-signed cert, run:
+# docker run --name keeweb -d -p 443:443 -p 80:80 -e 'DH_SIZE=512' antelle/keeweb
+
+FROM armhf/alpine:latest
+MAINTAINER Antelle "antelle.net@gmail.com"
+
+# install nginx
+RUN apk add --update bash nginx && \
+    mkdir -p /run/nginx/
+
+# install
+RUN apk add --update openssl wget unzip ca-certificates
+
+# setup nginx
+RUN rm -rf /etc/nginx/conf.d/*; \
+    mkdir -p /etc/nginx/external
+
+RUN sed -i 's/access_log.*/access_log \/dev\/stdout;/g' /etc/nginx/nginx.conf; \
+    sed -i 's/error_log.*/error_log \/dev\/stdout info;/g' /etc/nginx/nginx.conf; \
+    sed -i 's/error_log \/dev\/stdout info;/error_log \/dev\/stdout info;\n\n# daemon mode off\ndaemon off;/g' /etc/nginx/nginx.conf
+
+ADD keeweb.conf /etc/nginx/conf.d/keeweb.conf
+
+# clone keeweb
+RUN wget https://github.com/keeweb/keeweb/archive/gh-pages.zip; \
+    unzip gh-pages.zip; \
+    rm gh-pages.zip; \
+    mv keeweb-gh-pages keeweb; \
+    rm keeweb/CNAME
+
+# clone keeweb plugins
+RUN wget https://github.com/keeweb/keeweb-plugins/archive/master.zip; \
+    unzip master.zip; \
+    rm master.zip; \
+    mv keeweb-plugins-master/docs keeweb/plugins; \
+    rm -rf keeweb-plugins-master \
+    rm keeweb/plugins/CNAME
+
+ADD entrypoint.sh /opt/entrypoint.sh
+RUN chmod a+x /opt/entrypoint.sh
+
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD ["nginx"]
+
+EXPOSE 443
+EXPOSE 80

--- a/package/docker-rpi/LICENSE
+++ b/package/docker-rpi/LICENSE
@@ -1,0 +1,23 @@
+License of nginx-ssl-secure, https://github.com/MarvAmBass/docker-nginx-ssl-secure/
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Marvin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/docker-rpi/entrypoint.sh
+++ b/package/docker-rpi/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo "Welcome to KeeWeb docker container!"
+
+if [ -z ${DH_SIZE+x} ]
+then
+  >&2 echo ">> no \$DH_SIZE specified using default"
+  DH_SIZE="512"
+fi
+
+
+DH="/etc/nginx/external/dh.pem"
+
+if [ ! -e "$DH" ]
+then
+  echo ">> seems like the first start of nginx"
+  echo ">> doing some preparations..."
+  echo ""
+
+  echo ">> generating $DH with size: $DH_SIZE"
+  openssl dhparam -out "$DH" $DH_SIZE
+fi
+
+if [ ! -e "/etc/nginx/external/cert.pem" ] || [ ! -e "/etc/nginx/external/key.pem" ]
+then
+  echo ">> generating self signed cert"
+  openssl req -x509 -newkey rsa:4086 \
+  -subj "/C=XX/ST=XXXX/L=XXXX/O=XXXX/CN=localhost" \
+  -keyout "/etc/nginx/external/key.pem" \
+  -out "/etc/nginx/external/cert.pem" \
+  -days 3650 -nodes -sha256
+fi
+
+# exec CMD
+echo ">> exec docker CMD"
+echo "$@"
+exec "$@"

--- a/package/docker-rpi/keeweb.conf
+++ b/package/docker-rpi/keeweb.conf
@@ -1,0 +1,35 @@
+server {
+    listen 443 ssl;
+    root /keeweb;
+    index index.html;
+    server_name localhost;
+    ssl_certificate /etc/nginx/external/cert.pem;
+    ssl_certificate_key /etc/nginx/external/key.pem;
+
+    server_tokens off;
+    add_header X-Content-Type-Options nosniff;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
+    # https://scotthelme.co.uk/a-plus-rating-qualys-ssl-test/
+    # http://www.howtoforge.com/ssl-perfect-forward-secrecy-in-nginx-webserver
+
+    ssl_dhparam /etc/nginx/external/dh.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # disable poodle
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+    location ~ /\. {
+        deny all;
+    }
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
I implemented support to run the Docker image on a raspberry pi (armhf-based). I tried to keep it as close to possible to your original Dockerfile and therefore kept installing nginx (as there is no official armhf nginx package) and installing the rest in to separate RUNs. I also had to change the way how daemon off is set in nginx as your sed didn't work for me (there is no pid directive in the standard conf). Lastly I moved the entrypoint copy closer to the end as I played a lot with that script and docker build now only needs to change a few layers in the end if you change that file instead of always downloading from github