### PR TITLE
Fixes #531: Window icon scaling error on win32 Electron app

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -137,16 +137,19 @@ function readAppSettings() {
 
 function createMainWindow() {
     const appSettings = readAppSettings();
-    mainWindow = new electron.BrowserWindow({
+    const windowOptions = {
         show: false,
         width: 1000, height: 700, minWidth: 700, minHeight: 400,
-        icon: path.join(__dirname, 'icon.png'),
         titleBarStyle: appSettings ? appSettings.titlebarStyle : undefined,
         backgroundColor: '#282C34',
         webPreferences: {
             backgroundThrottling: false
         }
-    });
+    };
+    if (process.platform !== 'win32') {
+        windowOptions.icon = path.join(__dirname, 'icon.png');
+    }
+    mainWindow = new electron.BrowserWindow(windowOptions);
     setMenu();
     mainWindow.loadURL(htmlPath);
     if (showDevToolsOnStart) {


### PR DESCRIPTION
Fixes the scaling error reported in #531, caused by some issue with Electron and setting the icon on BrowserWindow on win32.
Instead, if we leave it out like I did now, it will use the icon for the Electron executable currently defined in the Gruntfile.
See https://github.com/atom/atom/issues/4811 for reference.

Current screenshot of result after packaging:
![iconscaling](https://user-images.githubusercontent.com/567466/34945925-3454cd20-fa05-11e7-84fc-e496806d599a.JPG)

Warning regards testing/validation: This will result in the default Atom icon being displayed when not actually packaging the electron app, e.g. when running 'npm run-script electron'