### PR TITLE
sign-html task can hang if it fails with --force

### DIFF
--- a/grunt/tasks/grunt-sign-html.js
+++ b/grunt/tasks/grunt-sign-html.js
@@ -26,6 +26,7 @@ module.exports = function (grunt) {
             } else {
                 grunt.warn('Sign error: ' + e);
             }
+            done(false);
         });
     });
 };


### PR DESCRIPTION
Hi everyone! I love this project and have been using it flawlessly on my Windows gaming desktop, as well as my work MacBook Pro.  I recently got a new presonal laptop that I'm using Arch Linux on and ended up having some issues getting this to build.

Long story short, the `sign-html` grunt task fails for me.  While I can avoid it with `--skip-sign`, I noticed some very strange behavior when `--force` was passed to grunt - this task would hang indefinitely!

Without my patch, running without `--force`, it fails as expected:

```
$ grunt sign-html 
>> Local Npm module "grunt-appdmg" not found. Is it installed?

Running "sign-html:app" (sign-html) task
Warning: Error signing app html. To build without sign, please launch grunt with --skip-sign. Use --force to continue.

Aborted due to warnings.


Execution Time (2018-06-28 13:19:08 UTC-4)
loading tasks  1.7s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 97%
sign-html:app  46ms  ▇▇▇ 3%
Total 1.7s

$ echo $?
6
```

Running without my patch but with `--force`, it hangs forever!

```
$ grunt sign-html --force
>> Local Npm module "grunt-appdmg" not found. Is it installed?

Running "sign-html:app" (sign-html) task
Warning: Error signing app html. To build without sign, please launch grunt with --skip-sign. Used --force, continuing.
```

It says it is continuing, but never actually does.

Investigating this, I noticed that when `this.async()` is called in a grunt task, it puts the task into async mode, meaning the `done` function needs to be called to let it know the task has finished.  However, `grunt.warn` appears to be a shortcut to abort the task.  `grunt.warn` works to signify the task is done when run normally, but NOT when run with `--force`.  I don't know why - this is my first time using `grunt`.

Regardless, with my patch, calling `grunt sign-html` normally works like before (fails, but this is expected)

```
$ grunt sign-html
>> Local Npm module "grunt-appdmg" not found. Is it installed?

Running "sign-html:app" (sign-html) task
Warning: Error signing app html. To build without sign, please launch grunt with --skip-sign. Use --force to continue.

Aborted due to warnings.


Execution Time (2018-06-28 13:21:50 UTC-4)
loading tasks  1.7s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 98%
sign-html:app  39ms  ▇▇ 2%
Total 1.7s

$ echo $?
6
```

And with `--force` it successfully moves on

```
$ grunt sign-html --force
>> Local Npm module "grunt-appdmg" not found. Is it installed?

Running "sign-html:app" (sign-html) task
Warning: Error signing app html. To build without sign, please launch grunt with --skip-sign. Used --force, continuing.
Warning: Task "sign-html:app" failed. Used --force, continuing.

Done, but with warnings.


Execution Time (2018-06-28 13:22:00 UTC-4)
loading tasks  1.7s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 98%
sign-html:app  41ms  ▇▇▇ 2%
Total 1.7s

$ echo $?
0
```

### conclusion

It appears that using `grunt.warn` to abort a task works only if `--force` is not present.  There are other grunt tasks that rely on this behavior and could probably break in the future.  I left them out of this PR because I'm a grunt newb, and I could be totally off here - this patch just worked for me in my testing.