### PR TITLE
Proper minimize to tray for Windows (and Linux?)

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -93,10 +93,11 @@ app.minimizeApp = function () {
         mainWindow.hide();
         app.dock.hide();
         imagePath = 'mac-menubar-icon.png';
+        mainWindow.setSkipTaskbar(true);
     } else {
+        mainWindow.hide();
         imagePath = 'icon.png';
     }
-    mainWindow.setSkipTaskbar(true);
     const image = electron.nativeImage.createFromPath(path.join(__dirname, imagePath));
     appIcon = new electron.Tray(image);
     appIcon.on('click', restoreMainWindow);
@@ -193,7 +194,7 @@ function restoreMainWindow() {
         mainWindow.restore();
     }
     mainWindow.setSkipTaskbar(false);
-    mainWindow.focus();
+    mainWindow.show();
     setTimeout(destroyAppIcon, 0);
 }
 


### PR DESCRIPTION
On Windows 7, this corrects the issue described in Issue #978.

Commit https://github.com/keeweb/keeweb/commit/d76cc891e17c93efc2b52de37db69bb28fd37792 broke minimize to tray on Windows: the tray icon appeared, but the window didn’t go away. This fixes that problem as well. The error appeared to be a result of a simple omission in the `minimizeApp` function when the Darwin and non-Darwin code paths were split; `MainWindow.minimize();` was left out of the non-Darwin path. The fix for both issues is to replace `MainWindow.minimize();` and `mainWindow.setSkipTaskbar(true);` with `mainWindow.hide();` in the non-Darwin path, and to replace `mainWindow.focus();` with `mainWindow.show();` in the `restoreMainWindow` function. This produces expected Windows behavior.

I have no way of testing this except on Windows 7. I had to base on develop branch since I see no way to build master on Windows.