### PR TITLE
Draggable field labels

### DIFF
--- a/app/scripts/views/app-view.js
+++ b/app/scripts/views/app-view.js
@@ -31,6 +31,7 @@ const AppView = Backbone.View.extend({
     events: {
         'contextmenu': 'contextMenu',
         'drop': 'drop',
+        'dragenter': 'dragover',
         'dragover': 'dragover',
         'click a[target=_blank]': 'extLinkClick',
         'mousedown': 'bodyClick'
@@ -678,6 +679,7 @@ const AppView = Backbone.View.extend({
 
     dragover: function(e) {
         e.preventDefault();
+        e.originalEvent.dataTransfer.dropEffect = 'none';
     },
 
     drop: function(e) {

--- a/app/scripts/views/details/details-view.js
+++ b/app/scripts/views/details/details-view.js
@@ -564,6 +564,7 @@ const DetailsView = Backbone.View.extend({
 
     dragover: function(e) {
         e.preventDefault();
+        e.stopPropagation();
         const dt = e.originalEvent.dataTransfer;
         if (!dt.types || (dt.types.indexOf ? dt.types.indexOf('Files') === -1 : !dt.types.contains('Files'))) {
             dt.dropEffect = 'none';

--- a/app/scripts/views/details/details-view.js
+++ b/app/scripts/views/details/details-view.js
@@ -564,6 +564,12 @@ const DetailsView = Backbone.View.extend({
 
     dragover: function(e) {
         e.preventDefault();
+        const dt = e.originalEvent.dataTransfer;
+        if (!dt.types || (dt.types.indexOf ? dt.types.indexOf('Files') === -1 : !dt.types.contains('Files'))) {
+            dt.dropEffect = 'none';
+            return;
+        }
+        dt.dropEffect = 'copy';
         if (this.dragTimeout) {
             clearTimeout(this.dragTimeout);
         }

--- a/app/scripts/views/fields/field-view.js
+++ b/app/scripts/views/fields/field-view.js
@@ -7,7 +7,8 @@ const FieldView = Backbone.View.extend({
 
     events: {
         'click .details__field-label': 'fieldLabelClick',
-        'click .details__field-value': 'fieldValueClick'
+        'click .details__field-value': 'fieldValueClick',
+        'dragstart .details__field-label': 'fieldLabelDrag'
     },
 
     render: function() {
@@ -90,6 +91,20 @@ const FieldView = Backbone.View.extend({
         }
     },
 
+    fieldLabelDrag: function(e) {
+        e.stopPropagation();
+        if (!this.value) {
+            return;
+        }
+        const dt = e.originalEvent.dataTransfer;
+        const txtval = this.value.isProtected ? this.value.getText() : this.value;
+        if (this.valueEl[0].tagName.toLowerCase() === 'a') {
+            dt.setData('text/uri-list', txtval);
+        }
+        dt.setData('text/plain', txtval);
+        dt.effectAllowed = 'copy';
+    },
+
     edit: function() {
         if (this.readonly || this.editing) {
             return;
@@ -98,6 +113,7 @@ const FieldView = Backbone.View.extend({
         this.startEdit();
         this.editing = true;
         this.preventCopy = true;
+        this.labelEl[0].setAttribute('draggable', 'false');
     },
 
     endEdit: function(newVal, extra) {
@@ -130,6 +146,7 @@ const FieldView = Backbone.View.extend({
         }
         this.valueEl.html(this.renderValue(this.value));
         this.$el.removeClass('details__field--edit');
+        this.labelEl[0].setAttribute('draggable', 'true');
     },
 
     triggerChange: function(arg) {

--- a/app/scripts/views/menu/menu-item-view.js
+++ b/app/scripts/views/menu/menu-item-view.js
@@ -199,8 +199,8 @@ const MenuItemView = Backbone.View.extend({
     },
 
     dragover(e) {
-        e.stopPropagation();
         if (this.model.get('drop') && this.dropAllowed(e)) {
+            e.stopPropagation();
             e.preventDefault();
             this.$el.addClass('menu__item--drag');
         }

--- a/app/scripts/views/open-view.js
+++ b/app/scripts/views/open-view.js
@@ -433,6 +433,13 @@ const OpenView = Backbone.View.extend({
             return;
         }
         e.preventDefault();
+        e.stopPropagation();
+        const dt = e.originalEvent.dataTransfer;
+        if (!dt.types || (dt.types.indexOf ? dt.types.indexOf('Files') === -1 : !dt.types.contains('Files'))) {
+            dt.dropEffect = 'none';
+            return;
+        }
+        dt.dropEffect = 'copy';
         if (this.dragTimeout) {
             clearTimeout(this.dragTimeout);
         }

--- a/app/styles/areas/_details.scss
+++ b/app/styles/areas/_details.scss
@@ -165,7 +165,6 @@
 
     &-label {
       @include th { color: th(muted-color); }
-      @include user-select(text);
       width: 7em;
       text-align: right;
       cursor: pointer;

--- a/app/templates/details/field.hbs
+++ b/app/templates/details/field.hbs
@@ -4,7 +4,7 @@
     {{~#if canEditTitle}} details__field--can-edit-title{{/if~}}
     {{~#if protect}} details__field--protect{{/if~}}
     ">
-    <div class="details__field-label">{{title}}</div>
+    <div class="details__field-label" draggable="true">{{title}}</div>
     <div class="details__field-value">
     </div>
 </div>


### PR DESCRIPTION
This implements the change requested in #970 by allowing field labels in the details view to be dragged. The value dragged is the same as the value copied to the clipboard by clicking on the label.

In testing I saw that as soon as the label began dragging, the “drop attachments here” message replaced the details view. While this didn’t interfere with dragging the field, it was somewhat jarring and unexpected.

Further investigation showed that in many places KeeWeb indicates that it is possible to drop something without first checking what is being dragged. https://github.com/keeweb/keeweb/commit/7a3cc9c863ce4a8460e83d925225638a97b53ea4 limits the “drop attachments here” message to appear only when a *file* is dragged across the details view. https://github.com/keeweb/keeweb/commit/2450e3a0b607203b9c7687424cff7dbd0d57f6d5 makes KeeWeb indicate that something can be dropped only when dragging an item of a type which can be dropped there. https://github.com/keeweb/keeweb/commit/0f1a248fcc7347aa52c6953c75bc7d58925123bf implements draggable field labels.

I’ve tested this only on Windows 7 with the desktop client and with Firefox, Chrome and Vivaldi.