### PR TITLE
Fix for Issue #877 - remove bad Origin header

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -60,6 +60,7 @@ app.on('ready', () => {
         setGlobalShortcuts();
         subscribePowerEvents();
         deleteOldTempFiles();
+        hookRequestHeaders();
     }
 });
 app.on('open-file', (e, path) => {
@@ -420,4 +421,15 @@ function deleteRecursive(dir) {
         }
     }
     fs.rmdirSync(dir);
+}
+
+// When sending a PUT XMLHttpRequest Chromium includes the header "Origin: file://".
+// This confuses some WebDAV clients, notably OwnCloud.
+// The header is invalid, so removing it everywhere it occurs should do no harm.
+
+function hookRequestHeaders() {
+    electron.session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+        delete details.requestHeaders['Origin'];
+        callback({cancel: false, requestHeaders: details.requestHeaders});
+    });
 }


### PR DESCRIPTION
I believe this will fix [#877 Issue with WebDav](https://github.com/keeweb/keeweb/issues/877).

It does need more testing than I can give it. It appears to make my OwnCloud installation work with KeeWeb, and it doesn’t appear to interfere with access to Google Drive. The changes are all in desktop/app.js, so the web version isn’t affected at all.

The underlying problem is that Chromium sends a mal-formed Origin header when it sees a PUT XMLHttpRequest from a local file. (Chromium sends `Origin: file://`; per [rfc6454](https://tools.ietf.org/html/rfc6454#section-7), only scheme://host and scheme://host:port are valid; if the origin does not have a scheme and a host, the literal value `none` must be used if the Origin header is supplied.)

The Origin header is supplied by the browser and can’t be rewritten using XMLHttpRequest; fortunately, Electron provides a global mechanism for trapping outgoing network requests via [webRequest](https://electronjs.org/docs/api/web-request).