### PR TITLE
Fix Issue #807 - single instance not enforced

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -1,5 +1,8 @@
 const electron = require('electron');
 const app = electron.app;
+
+if (app.makeSingleInstance(restoreMainWindow)) app.quit();
+
 const path = require('path');
 const fs = require('fs');
 
@@ -53,15 +56,13 @@ app.on('window-all-closed', () => {
     }
 });
 app.on('ready', () => {
-    if (!checkSingleInstance()) {
-        appReady = true;
-        setAppOptions();
-        createMainWindow();
-        setGlobalShortcuts();
-        subscribePowerEvents();
-        deleteOldTempFiles();
-        hookRequestHeaders();
-    }
+    appReady = true;
+    setAppOptions();
+    createMainWindow();
+    setGlobalShortcuts();
+    subscribePowerEvents();
+    deleteOldTempFiles();
+    hookRequestHeaders();
 });
 app.on('open-file', (e, path) => {
     e.preventDefault();
@@ -113,17 +114,6 @@ app.getMainWindow = function () {
     return mainWindow;
 };
 app.emitBackboneEvent = emitBackboneEvent;
-
-function checkSingleInstance() {
-    const shouldQuit = app.makeSingleInstance((/* commandLine, workingDirectory */) => {
-        restoreMainWindow();
-    });
-
-    if (shouldQuit) {
-        app.quit();
-    }
-    return shouldQuit;
-}
 
 function setAppOptions() {
     app.commandLine.appendSwitch('disable-background-timer-throttling');


### PR DESCRIPTION
This fixes issue #807 on Windows 7 and presumably elsewhere. All that was wrong is that we were checking for a previous instance in the app.on('ready') handler. We need to check in code that runs before that event gets raised.