### PR TITLE
Adjust some overflow behavior in the details panel, includes fixing Issue #945

### DIFF
--- a/app/styles/areas/_details.scss
+++ b/app/styles/areas/_details.scss
@@ -264,6 +264,12 @@
         font-weight: normal;
         @include user-select(none);
       }
+      >a {
+        max-width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
       .details__body-aside & {
         @include th { color: th(muted-color); }
         a { @include th { color: th(muted-color); } }
@@ -402,7 +408,6 @@
       position: absolute;
       bottom: $base-padding-v;
       right: $base-padding-h;
-      white-space: nowrap;
       opacity: .15;
       display: none;
       @include nomobile { display: block; }
@@ -461,12 +466,15 @@
     align-items: stretch;
     flex-direction: column;
     justify-content: flex-start;
-    margin-right: $base-padding-h;
+    max-width: 100%;
     &-top {
+      flex: 0 0 auto;
       display: flex;
       align-items: stretch;
       flex-direction: row;
       justify-content: flex-start;
+      padding-right: $base-padding-h;
+      margin-right: 20px;
     }
     &-desc {
       @include user-select(none);
@@ -529,6 +537,8 @@
       @include user-select(none);
       align-self: flex-end;
       margin-bottom: $base-padding-v;
+      padding-right: $base-padding-h;
+      margin-right: 20px;
     }
   }
 


### PR DESCRIPTION
Fix various glitches in details panel layout:

* Make long Website fields have the same width as other fields, and leave more than a sliver of space at the end in which to click to edit.

* Let the attachment download/delete instructions wrap if they are too long to fit on one line.

* Make fields in the history wrap the same way they do in the ordinary details pane (fixes #945).

* Avoid having the navigation area and the top of the history details overlap when the window height is too small to show everything without scrolling.

* Align the right edges of the history navigation area and the revert/delete buttons so that they don't overlap the scroll bar.