### PR TITLE
tray-min-auto-type-select-fix

### DIFF
--- a/app/scripts/comp/launcher-electron.js
+++ b/app/scripts/comp/launcher-electron.js
@@ -200,7 +200,7 @@ const Launcher = {
     hideApp: function() {
         const app = this.remoteApp();
         if (this.canMinimize()) {
-            app.getMainWindow().minimize();
+            app.minimizeThenHideIfInTray();
         } else {
             app.hide();
         }

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -91,24 +91,31 @@ app.openWindow = function (opts) {
 };
 app.minimizeApp = function () {
     let imagePath;
+    mainWindow.hide();
     if (process.platform === 'darwin') {
-        mainWindow.hide();
         app.dock.hide();
         imagePath = 'mac-menubar-icon.png';
-        mainWindow.setSkipTaskbar(true);
     } else {
-        mainWindow.hide();
         imagePath = 'icon.png';
     }
-    const image = electron.nativeImage.createFromPath(path.join(__dirname, imagePath));
-    appIcon = new electron.Tray(image);
-    appIcon.on('click', restoreMainWindow);
-    const contextMenu = electron.Menu.buildFromTemplate([
-        {label: 'Open KeeWeb', click: restoreMainWindow},
-        {label: 'Quit KeeWeb', click: closeMainWindow}
-    ]);
-    appIcon.setContextMenu(contextMenu);
-    appIcon.setToolTip('KeeWeb');
+    mainWindow.setSkipTaskbar(true);
+    if (!appIcon) {
+        const image = electron.nativeImage.createFromPath(path.join(__dirname, imagePath));
+        appIcon = new electron.Tray(image);
+        appIcon.on('click', restoreMainWindow);
+        const contextMenu = electron.Menu.buildFromTemplate([
+            {label: 'Open KeeWeb', click: restoreMainWindow},
+            {label: 'Quit KeeWeb', click: closeMainWindow}
+        ]);
+        appIcon.setContextMenu(contextMenu);
+        appIcon.setToolTip('KeeWeb');
+    }
+};
+app.minimizeThenHideIfInTray = function () {
+    // This function is called when auto-type has displayed a selection list and a selection was made.
+    // To ensure focus returns to the previous window we must minimize first even if we're going to hide.
+    mainWindow.minimize();
+    if (appIcon) mainWindow.hide();
 };
 app.getMainWindow = function () {
     return mainWindow;


### PR DESCRIPTION
The fix for alt-tab behavior when KeeWeb is minimized to the tray in 3dae878 left a problem when auto-type raises a selection list: the taskbar button shows, and after a selection is made KeeWeb minimizes
to the taskbar but leaves a tray icon present. The same thing happens if auto-type is canceled by clicking either the minimize button or the close button at the top right of the selection window. From this state, various scenarios lead to having duplicate tray icons.

This fix restores the behavior of 1.6.3 when auto-type raises a selection list while KeeWeb is minimized to the tray: the selection window shows, the tray icon stays, and no taskbar button shows.

There remains a case which is not handled perfectly: when KeeWeb is minimized to the tray, auto-type raises a selection list, and the user cancels auto-type by some means other than clicking the close button. This is a bit of a "corner case," the resultant behavior is "odd" but not unusable, and it would have to be handled in a different code path from the one affected by this commit, so I didn't attempt to include it in this fix.

Further details are in the commit comment.