### PR TITLE
Fix the link of list of issues which need help

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For debug build:
 
 Please, read contribution guidelines: [for issues](.github/ISSUE_TEMPLATE.md) and [for pull requests](.github/PULL_REQUEST_TEMPLATE.md).  
 For pull requests: branch is important! `master` is only for hotfixes, `develop` is for new features.  
-Here's a [list of issues](https://github.com/keeweb/keeweb/labels/need%20help) which need help.
+Here's a [list of issues](https://github.com/keeweb/keeweb/labels/help%20wanted) which need help.
 Also you can help by [translating KeeWeb](https://keeweb.oneskyapp.com) to your language.  
 
 ### Important notes for pull requests


### PR DESCRIPTION
This PR fixes the links of issues which need help, as the old label `need help` seems to no longer exist.