### PR TITLE
Allow custom default advancedSearch filters in settings json

### DIFF
--- a/app/scripts/models/app-model.js
+++ b/app/scripts/models/app-model.js
@@ -35,6 +35,7 @@ const AppModel = Backbone.Model.extend({
         this.settings = AppSettingsModel.instance;
         this.activeEntryId = null;
         this.isBeta = RuntimeInfo.beta;
+        this.advancedSearch = null;
 
         this.listenTo(Backbone, 'refresh', this.refresh);
         this.listenTo(Backbone, 'set-filter', this.setFilter);
@@ -131,6 +132,10 @@ const AppModel = Backbone.Model.extend({
             return Promise.all(pluginsPromises).then(() => {
                 this.settings.set(config.settings);
             });
+        }
+        if (config.advancedSearch) {
+            this.advancedSearch = config.advancedSearch;
+            this.addFilter({advanced: this.advancedSearch});
         }
     },
 

--- a/app/scripts/views/list-search-view.js
+++ b/app/scripts/views/list-search-view.js
@@ -57,6 +57,9 @@ const ListSearchView = Backbone.View.extend({
             cs: false, regex: false,
             history: false, title: true
         };
+        if (this.model.advancedSearch) {
+            this.advancedSearch = _.extend({}, this.model.advancedSearch);
+        }
         this.setLocale();
         KeyHandler.onKey(Keys.DOM_VK_F, this.findKeyPress, this, KeyHandler.SHORTCUT_ACTION);
         KeyHandler.onKey(Keys.DOM_VK_N, this.newKeyPress, this, KeyHandler.SHORTCUT_OPT);
@@ -199,7 +202,10 @@ const ListSearchView = Backbone.View.extend({
         }
         const sortIconCls = this.sortIcons[filter.sort] || 'sort';
         this.$el.find('.list__search-btn-sort>i').attr('class', 'fa fa-' + sortIconCls);
-        const adv = !!filter.filter.advanced;
+        let adv = !!filter.filter.advanced;
+        if (this.model.advancedSearch) {
+            adv = filter.filter.advanced !== this.model.advancedSearch;
+        }
         if (this.advancedSearchEnabled !== adv) {
             this.advancedSearchEnabled = adv;
             this.$el.find('.list__search-adv').toggleClass('hide', !this.advancedSearchEnabled);
@@ -224,7 +230,13 @@ const ListSearchView = Backbone.View.extend({
     advancedSearchClick: function() {
         this.advancedSearchEnabled = !this.advancedSearchEnabled;
         this.$el.find('.list__search-adv').toggleClass('hide', !this.advancedSearchEnabled);
-        Backbone.trigger('add-filter', { advanced: this.advancedSearchEnabled ? this.advancedSearch : false });
+        let advanced = false;
+        if (this.advancedSearchEnabled) {
+            advanced = this.advancedSearch;
+        } else if (this.model.advancedSearch) {
+            advanced = this.model.advancedSearch;
+        }
+        Backbone.trigger('add-filter', { advanced });
     },
 
     toggleMenu: function() {


### PR DESCRIPTION
In [this issue](https://github.com/keeweb/keeweb/issues/231) we had a discussion with @antelle about the ability customize default advancedSearch in json settings.
I've implemented this feature.

Add advancedSearch to your settings.json like this
```
{
  "settings": {
   ...
  },
  "advancedSearch": {
    "user": false,
    "other": true,
    "url": true,
    "protect": false,
    "notes": true,
    "pass": false,
    "cs": false,
    "regex": false,
    "history": false,
    "title": true
  },
  "showOnlyFilesFromConfig": false
}
```
and this filters will be activated by default instead of hard-coded ones.
