### PR TITLE
Fix: search filters UI opens when user clicks on folder with adancedSearch set in config.json

### DIFF
--- a/app/scripts/models/app-model.js
+++ b/app/scripts/models/app-model.js
@@ -242,6 +242,9 @@ const AppModel = Backbone.Model.extend({
     setFilter: function(filter) {
         this.filter = filter;
         this.filter.subGroups = this.settings.get('expandGroups');
+        if (!this.filter.advanced && this.advancedSearch) {
+            this.filter.advanced = this.advancedSearch;
+        }
         const entries = this.getEntries();
         if (!this.activeEntryId || !entries.get(this.activeEntryId)) {
             const firstEntry = entries.first();


### PR DESCRIPTION
Related to ["Allow custom default advancedSearch filters in settings json" pull request](https://github.com/keeweb/keeweb/pull/1061).