### PR TITLE
Check for a URL in the title for unsupported apps

### DIFF
--- a/app/scripts/auto-type/helper/auto-type-helper-darwin.js
+++ b/app/scripts/auto-type/helper/auto-type-helper-darwin.js
@@ -42,13 +42,7 @@ AutoTypeHelper.prototype.getActiveWindowTitle = function(callback) {
             // special cases are not available. this method may ask the user about assistive access
             AutoTypeHelper.exec(OtherAppsScript.replace(/\{}/g, appName), (err, out) => {
                 if (err) { return callback(err); }
-                // try to find a URL in the title
-                const urlMatcher = new RegExp(
-                    'https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)'
-                );
-                const urlMatches = urlMatcher.exec(out);
-                const url = urlMatches && urlMatches.length > 0 ? urlMatches[0] : null;
-                return callback(null, out.trim(), url);
+                return callback(null, out.trim());
             });
         }
     });

--- a/app/scripts/auto-type/index.js
+++ b/app/scripts/auto-type/index.js
@@ -164,6 +164,14 @@ const AutoType = {
             if (err) {
                 logger.error('Error get window title', err);
             } else {
+                if (!url) {
+                    // try to find a URL in the title
+                    const urlMatcher = new RegExp(
+                        'https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)'
+                    );
+                    const urlMatches = urlMatcher.exec(title);
+                    url = urlMatches && urlMatches.length > 0 ? urlMatches[0] : null;
+                }
                 logger.debug('Window title', title, url);
             }
             return callback(err, title, url);


### PR DESCRIPTION
This fixes #812, but I only included a Darwin implementation. What about the other platforms? I could easily move the regexp-tester to a mixin and use that in the other helpers. However, in the issue you spoke about implementing this only in the "non-supported apps" to avoid malicious things.