### PR TITLE
Remove a custom field from a template, better drag and drop visibility when moving folders

### DIFF
--- a/app/scripts/views/fields/field-view-custom.js
+++ b/app/scripts/views/fields/field-view-custom.js
@@ -68,6 +68,11 @@ const FieldViewCustom = FieldViewText.extend({
         if (newTitle && newTitle !== this.model.title) {
             this.model.title = newTitle;
             this.model.titleChanged = true;
+        } else if (newTitle === '') {
+            this.trigger('change', {
+                field: '$' + this.model.title,
+                val: ''
+            });
         }
         this.$el.find('.details__field-label').text(this.model.title);
         delete this.labelInput;

--- a/app/styles/areas/_menu.scss
+++ b/app/styles/areas/_menu.scss
@@ -171,12 +171,10 @@
       top: 0;
       left: 0;
       width: 100%;
-      height: 3px;
-      transition: background-color $slow-transition-out;
+      height: 5px;
     }
 
     &--drag-top > .menu__item-body > .menu__item-drag-top {
-      transition: background-color $slow-transition-in;
       @include th { background-color: th(action-color); }
     }
 


### PR DESCRIPTION
Fixes #791 for both mentioned issues there.

I implemented removing a custom field by emptying its title. Currently, this was only possible by emptying its value, which broke templates support. However, this introduces some kind of breaking change. Should I narrow this implementation so it only works for templates?