### PR TITLE
Add close window item to menu on Mac

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -322,7 +322,8 @@ function setMenu() {
             {
                 label: 'Window',
                 submenu: [
-                    { accelerator: 'CmdOrCtrl+M', role: 'minimize' }
+                    { accelerator: 'CmdOrCtrl+M', role: 'minimize' },
+                    { accelerator: 'Command+W', role: 'close' }
                 ]
             }
         ];


### PR DESCRIPTION
I realized close window shortcut doesn't work on Mac, therefore I added this item to menu.