### PR TITLE
dev-env.sh: allow to clone via http url

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To make Dropbox work in your self-hosted app, [go to this Wiki page](https://git
 
 The easiest way to clone all KeeWeb repos is:
 ```bash
-curl https://raw.githubusercontent.com/keeweb/keeweb/develop/dev-env.sh | bash -
+curl https://raw.githubusercontent.com/keeweb/keeweb/develop/dev-env.sh | SCHEMA=http bash -
 ```
 
 The app can be built with grunt: `grunt` (html file will be in `dist/`).    

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To make Dropbox work in your self-hosted app, [go to this Wiki page](https://git
 
 The easiest way to clone all KeeWeb repos is:
 ```bash
-curl https://raw.githubusercontent.com/keeweb/keeweb/develop/dev-env.sh | SCHEMA=http bash -
+curl https://raw.githubusercontent.com/keeweb/keeweb/develop/dev-env.sh | bash -
 ```
 
 The app can be built with grunt: `grunt` (html file will be in `dist/`).    

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -1,13 +1,32 @@
 #!/usr/bin/env bash
-echo Cloning KeeWeb into $PWD/keeweb...
+
+SCHEMA=${SCHEMA:-git}
+
+KEEWEB_GH=git@github.com:keeweb
+
+if [[ "$SCHEMA" == 'http' ]]; then
+    KEEWEB_GH=https://github.com/keeweb
+fi
+
+echo "Cloning KeeWeb ($KEEWEB_GH) into $PWD/keeweb..."
+
 mkdir keeweb
-git clone git@github.com:keeweb/favicon-proxy.git keeweb/favicon-proxy
-git clone git@github.com:keeweb/kdbxweb.git keeweb/kdbxweb
-git clone git@github.com:keeweb/keeweb.git -b develop keeweb/keeweb
-git clone git@github.com:keeweb/beta.keeweb.info.git keeweb/keeweb-beta
-git clone git@github.com:keeweb/keeweb-site.git -b gh-pages keeweb/keeweb-site
-git clone git@github.com:keeweb/keeweb-plugins.git keeweb/keeweb-plugins
-git clone git@github.com:keeweb/keeweb.git -b gh-pages --single-branch keeweb/keeweb-dist
+pushd keeweb >/dev/null
+
+git clone $KEEWEB_GH/keeweb.git -b develop keeweb
+
+pushd keeweb  >/dev/null
+git worktree add ../keeweb-dist gh-pages
+popd  >/dev/null
+
+git clone $KEEWEB_GH/favicon-proxy.git favicon-proxy
+git clone $KEEWEB_GH/kdbxweb.git kdbxweb
+git clone $KEEWEB_GH/beta.keeweb.info.git keeweb-beta
+git clone $KEEWEB_GH/keeweb-site.git -b gh-pages keeweb-site
+git clone $KEEWEB_GH/keeweb-plugins.git keeweb-plugins
+popd > /dev/null
+
 mkdir keeweb/keys
 echo kdbxweb/ > keeweb/.eslintignore
-echo Done! KeeWeb is cloned into $PWD/keeweb
+
+echo "Done! KeeWeb is cloned into $PWD/keeweb"


### PR DESCRIPTION
BTW, instead of cloning keeweb twice add a git-worktree for the gh-pages.

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>