### PR TITLE
dev-env.sh: use HTTP schema as default for cloning

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCHEMA=${SCHEMA:-git}
+SCHEMA=${SCHEMA:-http}
 
 KEEWEB_GH=git@github.com:keeweb
 


### PR DESCRIPTION
It's what will work for the most of users.

Suggested-by: @antelle
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>
