### PR TITLE
Focus search field when showing view

### DIFF
--- a/app/scripts/views/list-search-view.js
+++ b/app/scripts/views/list-search-view.js
@@ -99,6 +99,7 @@ const ListSearchView = Backbone.View.extend({
 
     viewShown: function() {
         this.listenTo(KeyHandler, 'keypress', this.documentKeyPress);
+        this.inputEl.focus();
     },
 
     viewHidden: function() {


### PR DESCRIPTION
Automatically focus on search input whenever a user lands on the main page. Won't work on iOS.