### PR TITLE
New Feature: Disable direct autotype

### DIFF
--- a/app/scripts/auto-type/index.js
+++ b/app/scripts/auto-type/index.js
@@ -199,7 +199,7 @@ const AutoType = {
 
     processEventWithFilter(evt) {
         const entries = evt.filter.getEntries();
-        if (entries.length === 1) {
+        if (entries.length === 1 && AppSettingsModel.instance.get('directAutotype')) {
             this.hideWindow(() => {
                 this.runAndHandleResult({ entry: entries.at(0) });
             });

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -358,6 +358,7 @@
   "setGenShowSubgroups": "Show entries from all subgroups",
   "setGenTableView": "Entries list table view",
   "setGenColorfulIcons": "Colorful custom icons in list",
+  "setGenDirectAutotype": "Directly run autotype, if an entry can be directly selected",
   "setGenFunction": "Function",
   "setGenAutoSyncOnClose": "Automatically save and sync on close",
   "setGenAutoSyncTimer": "Automatically save and sync periodically",

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -358,7 +358,7 @@
   "setGenShowSubgroups": "Show entries from all subgroups",
   "setGenTableView": "Entries list table view",
   "setGenColorfulIcons": "Colorful custom icons in list",
-  "setGenDirectAutotype": "Directly run autotype, if an entry can be directly selected",
+  "setGenDirectAutotype": "If only one matching entry is found, select that one automatically for Autotype",
   "setGenFunction": "Function",
   "setGenAutoSyncOnClose": "Automatically save and sync on close",
   "setGenAutoSyncTimer": "Automatically save and sync periodically",

--- a/app/scripts/models/app-settings-model.js
+++ b/app/scripts/models/app-settings-model.js
@@ -18,6 +18,7 @@ const AppSettingsModel = Backbone.Model.extend({
         minimizeOnClose: false,
         tableView: false,
         colorfulIcons: false,
+        directAutotype: true,
         titlebarStyle: 'default',
         lockOnMinimize: true,
         lockOnCopy: false,

--- a/app/scripts/views/settings/settings-general-view.js
+++ b/app/scripts/views/settings/settings-general-view.js
@@ -37,6 +37,7 @@ const SettingsGeneralView = Backbone.View.extend({
         'change .settings__general-lock-on-os-lock': 'changeLockOnOsLock',
         'change .settings__general-table-view': 'changeTableView',
         'change .settings__general-colorful-icons': 'changeColorfulIcons',
+        'change .settings__general-direct-autotype': 'changeDirectAutotype',
         'change .settings__general-titlebar-style': 'changeTitlebarStyle',
         'click .settings__general-update-btn': 'checkUpdate',
         'click .settings__general-restart-btn': 'restartApp',
@@ -101,6 +102,7 @@ const SettingsGeneralView = Backbone.View.extend({
             updateManual: updateManual,
             releaseNotesLink: Links.ReleaseNotes,
             colorfulIcons: AppSettingsModel.instance.get('colorfulIcons'),
+            directAutotype: AppSettingsModel.instance.get('directAutotype'),
             supportsTitleBarStyles: Launcher && FeatureDetector.supportsTitleBarStyles(),
             titlebarStyle: AppSettingsModel.instance.get('titlebarStyle'),
             storageProviders: storageProviders
@@ -272,6 +274,12 @@ const SettingsGeneralView = Backbone.View.extend({
     changeColorfulIcons: function(e) {
         const colorfulIcons = e.target.checked || false;
         AppSettingsModel.instance.set('colorfulIcons', colorfulIcons);
+        Backbone.trigger('refresh');
+    },
+
+    changeDirectAutotype: function(e) {
+        const directAutotype = e.target.checked || false;
+        AppSettingsModel.instance.set('directAutotype', directAutotype);
         Backbone.trigger('refresh');
     },
 

--- a/app/templates/settings/settings-general.hbs
+++ b/app/templates/settings/settings-general.hbs
@@ -88,11 +88,6 @@
         <input type="checkbox" class="settings__input input-base settings__general-colorful-icons" id="settings__general-colorful-icons" {{#if colorfulIcons}}checked{{/if}} />
         <label for="settings__general-colorful-icons">{{res 'setGenColorfulIcons'}}</label>
     </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-direct-autotype"
-            id="settings__general-direct-autotype" {{#if directAutotype}}checked{{/if}} />
-        <label for="settings__general-direct-autotype">{{res 'setGenDirectAutotype'}}</label>
-    </div>
 
     <h2>{{res 'setGenFunction'}}</h2>
     {{#if canAutoSaveOnClose}}
@@ -144,6 +139,13 @@
         <input type="checkbox" class="settings__input input-base settings__general-minimize" id="settings__general-minimize"
             {{#if minimizeOnClose}}checked{{/if}} />
         <label for="settings__general-minimize">{{res 'setGenMinInstead'}}</label>
+    </div>
+    {{/if}}
+    {{#if canAutoType}}
+    <div>
+        <input type="checkbox" class="settings__input input-base settings__general-direct-autotype"
+            id="settings__general-direct-autotype" {{#if directAutotype}}checked{{/if}} />
+        <label for="settings__general-direct-autotype">{{res 'setGenDirectAutotype'}}</label>
     </div>
     {{/if}}
 

--- a/app/templates/settings/settings-general.hbs
+++ b/app/templates/settings/settings-general.hbs
@@ -88,6 +88,11 @@
         <input type="checkbox" class="settings__input input-base settings__general-colorful-icons" id="settings__general-colorful-icons" {{#if colorfulIcons}}checked{{/if}} />
         <label for="settings__general-colorful-icons">{{res 'setGenColorfulIcons'}}</label>
     </div>
+    <div>
+        <input type="checkbox" class="settings__input input-base settings__general-direct-autotype"
+            id="settings__general-direct-autotype" {{#if directAutotype}}checked{{/if}} />
+        <label for="settings__general-direct-autotype">{{res 'setGenDirectAutotype'}}</label>
+    </div>
 
     <h2>{{res 'setGenFunction'}}</h2>
     {{#if canAutoSaveOnClose}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4385,8 +4385,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -4407,14 +4406,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4429,20 +4426,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4559,8 +4553,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -4572,7 +4565,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4587,7 +4579,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4595,14 +4586,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4621,7 +4610,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4702,8 +4690,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4715,7 +4702,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4801,8 +4787,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4838,7 +4823,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4858,7 +4842,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4902,14 +4885,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -5353,7 +5334,7 @@
       "version": "github:keeweb/grunt-contrib-deb#e9b6e9f6faab0f67512b4168a80b4dfbb0e0b68f",
       "from": "github:keeweb/grunt-contrib-deb#e9b6e9f",
       "requires": {
-        "ar-async": "git+https://github.com/JayCanuck/node-ar-async.git",
+        "ar-async": "git+https://github.com/JayCanuck/node-ar-async.git#cd5fa957b30db58d660d3f51bc64f16ab688c162",
         "async": "^1.5.0",
         "tar-stream": "^1.3.1"
       }
@@ -6193,8 +6174,7 @@
     "imul": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
-      "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
-      "optional": true
+      "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -6610,8 +6590,7 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "optional": true
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -6815,9 +6794,9 @@
       "resolved": "https://registry.npmjs.org/kdbxweb/-/kdbxweb-1.2.6.tgz",
       "integrity": "sha512-9KJlanItY6D2CmR/TN27HINwugSPNATD9yWq4V56JAxVUTY8WHveC5H0llLiyxgPHfr7eejPk8hmj98l/lq7Cw==",
       "requires": {
-        "pako": "pako@github:keeweb/pako#653c0b00d8941c89d09ed4546d2179001ec44efc",
-        "text-encoding": "text-encoding@github:keeweb/text-encoding#4dfb7cb0954c222852092f8b06ae4f6b4f60bfbb",
-        "xmldom": "xmldom@github:keeweb/xmldom#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
+        "pako": "github:keeweb/pako#653c0b00d8941c89d09ed4546d2179001ec44efc",
+        "text-encoding": "github:keeweb/text-encoding#4dfb7cb0954c222852092f8b06ae4f6b4f60bfbb",
+        "xmldom": "github:keeweb/xmldom#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
       },
       "dependencies": {
         "abbrev": {
@@ -7544,8 +7523,7 @@
             "ansi-regex": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-              "optional": true
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
             },
             "ansi-styles": {
               "version": "2.2.1",
@@ -7602,8 +7580,7 @@
             "balanced-match": {
               "version": "0.4.2",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-              "optional": true
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
             },
             "bcrypt-pbkdf": {
               "version": "1.0.0",
@@ -7618,7 +7595,6 @@
               "version": "0.0.9",
               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
               "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-              "optional": true,
               "requires": {
                 "inherits": "~2.0.0"
               }
@@ -7627,7 +7603,6 @@
               "version": "2.10.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "optional": true,
               "requires": {
                 "hoek": "2.x.x"
               }
@@ -7636,7 +7611,6 @@
               "version": "1.1.6",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-              "optional": true,
               "requires": {
                 "balanced-match": "^0.4.1",
                 "concat-map": "0.0.1"
@@ -7645,8 +7619,7 @@
             "buffer-shims": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-              "optional": true
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
             },
             "caseless": {
               "version": "0.11.0",
@@ -7678,14 +7651,12 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "optional": true
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "combined-stream": {
               "version": "1.0.5",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-              "optional": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
               }
@@ -7702,20 +7673,17 @@
             "concat-map": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "optional": true
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "optional": true
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "core-util-is": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-              "optional": true
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "cryptiles": {
               "version": "2.0.5",
@@ -7761,8 +7729,7 @@
             "delayed-stream": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-              "optional": true
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
             },
             "delegates": {
               "version": "1.0.0",
@@ -7794,8 +7761,7 @@
             "extsprintf": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-              "optional": true
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -7817,14 +7783,12 @@
             "fs.realpath": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "optional": true
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "fstream": {
               "version": "1.0.10",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
               "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-              "optional": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -7896,7 +7860,6 @@
               "version": "7.1.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-              "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -7909,8 +7872,7 @@
             "graceful-fs": {
               "version": "4.1.11",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-              "optional": true
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
             },
             "graceful-readlink": {
               "version": "1.0.1",
@@ -7960,8 +7922,7 @@
             "hoek": {
               "version": "2.16.3",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "optional": true
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
             },
             "http-signature": {
               "version": "1.1.1",
@@ -7978,7 +7939,6 @@
               "version": "1.0.6",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "optional": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -7987,8 +7947,7 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "optional": true
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.4",
@@ -8000,7 +7959,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8032,8 +7990,7 @@
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "optional": true
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "isstream": {
               "version": "0.1.2",
@@ -8088,14 +8045,12 @@
             "mime-db": {
               "version": "1.25.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-              "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-              "optional": true
+              "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
             },
             "mime-types": {
               "version": "2.1.13",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-              "optional": true,
               "requires": {
                 "mime-db": "~1.25.0"
               }
@@ -8104,7 +8059,6 @@
               "version": "3.0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.0.0"
               }
@@ -8112,14 +8066,12 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "optional": true
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             },
             "mkdirp": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8171,8 +8123,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "optional": true
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "oauth-sign": {
               "version": "0.8.2",
@@ -8190,7 +8141,6 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8198,8 +8148,7 @@
             "path-is-absolute": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "optional": true
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
             },
             "pinkie": {
               "version": "2.0.4",
@@ -8219,8 +8168,7 @@
             "process-nextick-args": {
               "version": "1.0.7",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-              "optional": true
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
             },
             "punycode": {
               "version": "1.4.1",
@@ -8301,7 +8249,6 @@
               "version": "2.5.4",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-              "optional": true,
               "requires": {
                 "glob": "^7.0.5"
               }
@@ -8362,7 +8309,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8372,8 +8318,7 @@
             "string_decoder": {
               "version": "0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "optional": true
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             },
             "stringstream": {
               "version": "0.0.5",
@@ -8385,7 +8330,6 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8406,7 +8350,6 @@
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-              "optional": true,
               "requires": {
                 "block-stream": "*",
                 "fstream": "^1.0.2",
@@ -8485,8 +8428,7 @@
             "util-deprecate": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-              "optional": true
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
             },
             "uuid": {
               "version": "3.0.1",
@@ -8515,8 +8457,7 @@
             "wrappy": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "optional": true
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             },
             "xtend": {
               "version": "4.0.1",
@@ -11230,8 +11171,7 @@
     "path-key": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-      "optional": true
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
     },
     "path-parse": {
       "version": "1.0.6",


### PR DESCRIPTION
In this PR I implemented a setting to disable the direct run of Autotype if one specific entry can be found.

This is something I need in connection to the feature of specifically entering only the password or username using Autotype.

The default value of this setting is *true*, which mimics the current behavior, so this is backwards compatible and should be valid for a minor version bump.