### PR TITLE
Prevent default on details copy keyboard shortcuts

### DIFF
--- a/app/scripts/views/details/details-view.js
+++ b/app/scripts/views/details/details-view.js
@@ -74,9 +74,9 @@ const DetailsView = Backbone.View.extend({
         this.listenTo(Backbone, 'set-locale', this.render);
         this.listenTo(OtpQrReader, 'qr-read', this.otpCodeRead);
         this.listenTo(OtpQrReader, 'enter-manually', this.otpEnterManually);
-        KeyHandler.onKey(Keys.DOM_VK_C, this.copyPassword, this, KeyHandler.SHORTCUT_ACTION, false, true);
-        KeyHandler.onKey(Keys.DOM_VK_B, this.copyUserName, this, KeyHandler.SHORTCUT_ACTION, false, true);
-        KeyHandler.onKey(Keys.DOM_VK_U, this.copyUrl, this, KeyHandler.SHORTCUT_ACTION, false, true);
+        KeyHandler.onKey(Keys.DOM_VK_C, this.copyPassword, this, KeyHandler.SHORTCUT_ACTION);
+        KeyHandler.onKey(Keys.DOM_VK_B, this.copyUserName, this, KeyHandler.SHORTCUT_ACTION);
+        KeyHandler.onKey(Keys.DOM_VK_U, this.copyUrl, this, KeyHandler.SHORTCUT_ACTION);
         if (AutoType.enabled) {
             KeyHandler.onKey(Keys.DOM_VK_T, this.autoType, this, KeyHandler.SHORTCUT_ACTION);
         }


### PR DESCRIPTION
This fixes a bug in Chrome where the "View Source" feature is invoked when attempting to copy the URL value via Ctrl+U (at least on Linux Chromium).

I've applied the same change to C and B for consistency and future-proofing, although I see no current bugs caused by the existing behaviour of allowing the events to attempt their default actions (presumably they are a noop in most browsers since no text is selected at the time).

Tested in browsers but not electron.
