### PR TITLE
Update Launcher.showMainWindow

### DIFF
--- a/app/scripts/comp/launcher-electron.js
+++ b/app/scripts/comp/launcher-electron.js
@@ -211,7 +211,7 @@ const Launcher = {
     },
     showMainWindow: function() {
         const win = this.getMainWindow();
-        win.show();
+        win.focus();
         win.restore();
     },
     spawn: function(config) {


### PR DESCRIPTION
Use [`app.focus()`](https://electronjs.org/docs/api/app#appfocus) instead of `app.show()` which the docs suggest is specific to MacOS.

Fixes #1095
