### PR TITLE
Change string comparator last char value to 0xfffd

### DIFF
--- a/app/scripts/util/comparators.js
+++ b/app/scripts/util/comparators.js
@@ -1,4 +1,4 @@
-const LastChar = String.fromCharCode(0xffffffff);
+const LastChar = String.fromCharCode(0xfffd);
 
 const ciCompare = (window.Intl && window.Intl.Collator && !/Edge/.test(navigator.userAgent)) // bugged in Edge: #808
     ? new Intl.Collator(undefined, { sensitivity: 'base' }).compare


### PR DESCRIPTION
Fixes #1147 

The only risks I see are:

1) If a user has an "Invalid Character" in their titles (or other strings compared by this function) the sort order will change.
2) If other JS runtimes perform a comparison using UTF32 characters.

(1) Seems irrelevant; Unlikely such characters have any benefit for users and may cause a whole host of other problems in KeeWeb other kdbx-based apps anyway.
(2) Seems unlikely since the fromCharCode spec only accepts UTF16 characters so any deviation is likely to be a significant bug in those runtimes. At least the behaviour of `0xffff` is identical to `0xffffffff` in Chromium and Firefox.

I've tested a fixed version (via Kee Vault) in Edge, Chrome and Firefox. Happy to test on my Windows machine using the KeeWeb beta site when the fix is merged, although Windows' update notifications suggest I'll probably be on a newer version of Edge by then.
