### PR TITLE
Improve reliability of emptying trash

### DIFF
--- a/app/scripts/models/file-model.js
+++ b/app/scripts/models/file-model.js
@@ -575,10 +575,11 @@ const FileModel = Backbone.Model.extend({
                 this.db.move(group, null);
                 modified = true;
             }, this);
-            trashGroup.group.entries.forEach(function(entry) {
+            trashGroup.group.entries.slice().forEach(function(entry) {
                 this.db.move(entry, null);
                 modified = true;
             }, this);
+            trashGroup.get('items').reset();
             trashGroup.get('entries').reset();
             if (modified) {
                 this.setModified();


### PR DESCRIPTION
* Makes the list of entries to delete immutable to ensure all are moved to the null group
* Resets model items to ensure view shows that groups and their contents have been deleted

Tested in Kee Vault on Firefox and Chrome