### PR TITLE
hide menubar

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -346,6 +346,9 @@ function setMenu() {
         const menu = electron.Menu.buildFromTemplate(template);
         electron.Menu.setApplicationMenu(menu);
     }
+    if (['win32', 'linux'].includes(process.platform)) {
+        mainWindow.setMenuBarVisibility(false);
+    }
 }
 
 function onContextMenu(e, props) {


### PR DESCRIPTION
[`setMenuBarVisibility`](https://electronjs.org/docs/api/browser-window#winsetmenubarvisibilityvisible-windows-linux) can be used to hide the menubar in electron v6.

fixes #1232, although I wasn't sure where you would want the code to go
