### PR TITLE
Copy OTP support in autotype. Was requested in #1190 and #963

### DIFF
--- a/app/scripts/auto-type/index.js
+++ b/app/scripts/auto-type/index.js
@@ -78,6 +78,8 @@ const AutoType = {
             sequence = '{PASSWORD}';
         } else if (result.sequenceType === AutoTypeSequenceType.USERNAME) {
             sequence = '{USERNAME}';
+        } else if (result.sequenceType === AutoTypeSequenceType.OTP) {
+            sequence = '{TOTP}';
         } else {
             sequence = result.entry.getEffectiveAutoTypeSeq();
         }

--- a/app/scripts/comp/key-handler.js
+++ b/app/scripts/comp/key-handler.js
@@ -7,6 +7,7 @@ const shortcutKeyProp = navigator.platform.indexOf('Mac') >= 0 ? 'metaKey' : 'ct
 const KeyHandler = {
     SHORTCUT_ACTION: 1,
     SHORTCUT_OPT: 2,
+    SHORTCUT_CTRL: 3,
 
     shortcuts: {},
     modal: false,
@@ -70,6 +71,11 @@ const KeyHandler = {
                         break;
                     case this.SHORTCUT_OPT:
                         if (!e.altKey) {
+                            continue;
+                        }
+                        break;
+                    case this.SHORTCUT_CTRL:
+                        if (!e.ctrlKey) {
                             continue;
                         }
                         break;

--- a/app/scripts/const/autotype-sequencetype.js
+++ b/app/scripts/const/autotype-sequencetype.js
@@ -1,7 +1,8 @@
 const AutoTypeSequenceType = {
     DEFAULT: 0,
     USERNAME: 1,
-    PASSWORD: 2
+    PASSWORD: 2,
+    OTP: 3
 };
 
 module.exports = AutoTypeSequenceType;

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -316,6 +316,7 @@
     "autoTypeSelectionHint": "Type the autotype sequence",
     "autoTypeSelectionHintAction": "Only type the password",
     "autoTypeSelectionHintOpt": "Only type the username",
+    "autoTypeSelectionHintCtrl": "Only type the OTP",
 
     "appSecWarn": "Not Secure!",
     "appSecWarnBody1": "You have loaded this app with an insecure connection. Someone may be watching you and stealing your passwords. We strongly advise you to stop, unless you clearly understand what you're doing.",

--- a/app/scripts/util/feature-detector.js
+++ b/app/scripts/util/feature-detector.js
@@ -23,6 +23,9 @@ const FeatureDetector = {
     altShortcutSymbol(formatting) {
         return this.isMac ? '⌥' : formatting ? '<span class="thin">alt + </span>' : 'alt-';
     },
+    ctrlShortcutSymbol(formatting) {
+        return this.isMac ? '⌃' : formatting ? '<span class="thin">ctrl + </span>' : 'alt-';
+    },
     globalShortcutSymbol(formatting) {
         return this.isMac
             ? '⌃⌥'

--- a/app/scripts/views/auto-type/auto-type-select-view.js
+++ b/app/scripts/views/auto-type/auto-type-select-view.js
@@ -46,6 +46,13 @@ const AutoTypePopupView = Backbone.View.extend({
             KeyHandler.SHORTCUT_OPT,
             true
         );
+        KeyHandler.onKey(
+            Keys.DOM_VK_RETURN,
+            this.ctrlEnterPressed,
+            this,
+            KeyHandler.SHORTCUT_CTRL,
+            true
+        );
         KeyHandler.onKey(Keys.DOM_VK_UP, this.upPressed, this, false, true);
         KeyHandler.onKey(Keys.DOM_VK_DOWN, this.downPressed, this, false, true);
         KeyHandler.onKey(Keys.DOM_VK_BACK_SPACE, this.backSpacePressed, this, false, true);
@@ -99,9 +106,11 @@ const AutoTypePopupView = Backbone.View.extend({
             selectionHintDefault: Locale.autoTypeSelectionHint,
             selectionHintAction: Locale.autoTypeSelectionHintAction,
             selectionHintOpt: Locale.autoTypeSelectionHintOpt,
+            selectionHintCtrl: Locale.autoTypeSelectionHintCtrl,
             itemsHtml,
             actionSymbol: FeatureDetector.actionShortcutSymbol(true),
             altSymbol: FeatureDetector.altShortcutSymbol(true),
+            ctrlSymbol: FeatureDetector.ctrlShortcutSymbol(true),
             keyEnter: Locale.keyEnter
         });
         document.activeElement.blur();
@@ -151,6 +160,10 @@ const AutoTypePopupView = Backbone.View.extend({
 
     optEnterPressed() {
         this.closeWithResult(AutoTypeSequenceType.USERNAME);
+    },
+
+    ctrlEnterPressed() {
+        this.closeWithResult(AutoTypeSequenceType.OTP);
     },
 
     openKeyPressed() {

--- a/app/templates/auto-type/auto-type-select.hbs
+++ b/app/templates/auto-type/auto-type-select.hbs
@@ -5,6 +5,7 @@
             <div class="at-select__hint-text"><span class="shortcut">{{keyEnter}}</span>: {{selectionHintDefault}}</div>
             <div class="at-select__hint-text"><span class="shortcut">{{{actionSymbol}}} {{keyEnter}}</span>: {{selectionHintAction}}</div>
             <div class="at-select__hint-text"><span class="shortcut">{{{altSymbol}}} {{keyEnter}}</span>: {{selectionHintOpt}}</div>
+            <div class="at-select__hint-text"><span class="shortcut">{{{ctrlSymbol}}} {{keyEnter}}</span>: {{selectionHintCtrl}}</div>
         </div>
         {{#if filterText}}
         <div class="at-select__header-filter">


### PR DESCRIPTION
Hey antelle!

It's me again implementing a feature I need 😉 
This was partly requested in #1190 and #963. It supports only inserting the OTP in autotype much like the existing features to insert only the username and password.

I have selected CTRL + Enter for this feature. Please take a look.