### PR TITLE
Issue 1125

### DIFF
--- a/app/scripts/views/fields/field-view-read-only.js
+++ b/app/scripts/views/fields/field-view-read-only.js
@@ -5,10 +5,10 @@ class FieldViewReadOnly extends FieldView {
     readonly = true;
 
     renderValue(value) {
-        value =
-            value.isProtected && !this.unsafeMode
-                ? new Array(value.textLength + 1).join('•')
-                : escape(value);
+        if (value.isProtected && this.unsafeMode) {
+            return value.getText();
+        }
+        value = value.isProtected ? new Array(value.textLength + 1).join('•') : escape(value);
         value = value.replace(/\n/g, '<br/>');
         return value;
     }

--- a/app/scripts/views/fields/field-view-read-only.js
+++ b/app/scripts/views/fields/field-view-read-only.js
@@ -5,7 +5,10 @@ class FieldViewReadOnly extends FieldView {
     readonly = true;
 
     renderValue(value) {
-        value = value.isProtected ? new Array(value.textLength + 1).join('•') : escape(value);
+        value =
+            value.isProtected && !this.unsafeMode
+                ? new Array(value.textLength + 1).join('•')
+                : escape(value);
         value = value.replace(/\n/g, '<br/>');
         return value;
     }

--- a/app/scripts/views/fields/field-view-text.js
+++ b/app/scripts/views/fields/field-view-text.js
@@ -17,6 +17,9 @@ class FieldViewText extends FieldView {
     }
 
     renderValue(value) {
+        if (this.unsafeMode) {
+            return value.getText();
+        }
         if (this.model.markdown) {
             if (value && value.isProtected) {
                 value = value.getText();

--- a/app/scripts/views/fields/field-view-text.js
+++ b/app/scripts/views/fields/field-view-text.js
@@ -17,7 +17,7 @@ class FieldViewText extends FieldView {
     }
 
     renderValue(value) {
-        if (this.unsafeMode) {
+        if (value.isProtected && this.unsafeMode) {
             return value.getText();
         }
         if (this.model.markdown) {

--- a/app/scripts/views/fields/field-view.js
+++ b/app/scripts/views/fields/field-view.js
@@ -10,8 +10,13 @@ class FieldView extends View {
     events = {
         'click .details__field-label': 'fieldLabelClick',
         'click .details__field-value': 'fieldValueClick',
-        'dragstart .details__field-label': 'fieldLabelDrag'
+        'dragstart .details__field-label': 'fieldLabelDrag',
+        'mouseover .details__field-value': 'fieldValueMouseOver',
+        'mouseout .details__field-value': 'fieldValueMouseOut'
     };
+
+    unsafeMode = false;
+    unsafeTimeout = null;
 
     constructor(model, options) {
         super(model, options);
@@ -30,7 +35,7 @@ class FieldView extends View {
             multiline: this.model.multiline,
             title: this.model.title,
             canEditTitle: this.model.newField,
-            protect: this.value && this.value.isProtected
+            protect: !this.unsafeMode && this.value && this.value.isProtected
         });
         this.valueEl = this.$el.find('.details__field-value');
         this.valueEl.html(this.renderValue(this.value));
@@ -99,7 +104,30 @@ class FieldView extends View {
         }
         const sel = window.getSelection().toString();
         if (!sel) {
+            this.unsafeMode = false;
             this.edit();
+        }
+    }
+
+    fieldValueMouseOver(e) {
+        if (!this.editing) {
+            if (!this.unsafeTimeout) {
+                this.unsafeTimeout = window.setTimeout(() => {
+                    this.unsafeMode = e.altKey;
+                    this.render();
+                }, 1000);
+            }
+        }
+    }
+
+    fieldValueMouseOut(e) {
+        if (this.unsafeTimeout) {
+            window.clearTimeout(this.unsafeTimeout);
+            this.unsafeTimeout = null;
+        }
+        if (this.unsafeMode) {
+            this.unsafeMode = false;
+            this.render();
         }
     }
 


### PR DESCRIPTION
This is a suggestion for #1125. When you hold alt and hover over a field, then after a second the value is shown. If you move the mouse out, the value is hidden again.

Let me know what you think. Especially the security implications have to be checked. I know you took some great lengths to hide the values from browser memory.

Also, I added the second delay on purpose to suppress the function if used by accident. In the current implementation, the alt key has to be pressed when the mouse reaches the field. If the hover starts and the alt key is pressed after that, it doesn't work. That maybe confusing, right?