### PR TITLE
fix(#1142): Added submit button in login form for mobile screens

### DIFF
--- a/app/styles/areas/_open.scss
+++ b/app/styles/areas/_open.scss
@@ -80,7 +80,6 @@
             @include mobile {
                 width: 100%;
                 box-sizing: border-box;
-                padding: 010px;
             }
         }
         &-warn-wrap {
@@ -121,6 +120,12 @@
                 cursor: pointer;
                 &:hover {
                     color: var(--medium-color);
+                }
+                @include mobile {
+                    width: 28px;
+                    text-align: center;
+                    padding: 0.6em 10px;
+                    margin-left: 1px;
                 }
             }
             .open--opening & {
@@ -184,7 +189,8 @@
             cursor: pointer;
         }
         @include mobile {
-            width: calc(100vw - 20px - 66px);
+            width: calc(100vw - 10px - 48px);
+            margin-left: 10px;
         }
     }
 

--- a/app/styles/areas/_open.scss
+++ b/app/styles/areas/_open.scss
@@ -79,7 +79,6 @@
             }
             @include mobile {
                 width: 100%;
-                box-sizing: border-box;
             }
         }
         &-warn-wrap {

--- a/app/styles/areas/_open.scss
+++ b/app/styles/areas/_open.scss
@@ -77,6 +77,11 @@
             .open--drag & {
                 display: none;
             }
+            @include mobile {
+                width: 100%;
+                box-sizing: border-box;
+                padding: 010px;
+            }
         }
         &-warn-wrap {
             display: flex;
@@ -97,7 +102,8 @@
             position: absolute;
             left: 100%;
             @include mobile {
-                display: none;
+                position: relative;
+                left: auto;
             }
             color: var(--muted-color);
             > i {
@@ -178,7 +184,7 @@
             cursor: pointer;
         }
         @include mobile {
-            width: calc(100vw - 20px);
+            width: calc(100vw - 20px - 66px);
         }
     }
 


### PR DESCRIPTION
Changes to style file to fix #1142 issue
Now 'open__pass-enter-btn' is correctly aligned, there are 10px (like actual version) between each space.
Note that this button use 'fa-rotate-90' class and without some adjustments doesn't allow to position correctly.
![Image 145](https://user-images.githubusercontent.com/47756116/66119778-a9be5d80-e5d9-11e9-81af-1336412a62a9.jpg)
