### PR TITLE
remove duplicate apple-mobile-web-app-capable meta tag

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,6 @@
             content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
         />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="apple-mobile-web-app-title" content="KeeWeb" />
         <meta name="theme-color" content="#6386ec" />


### PR DESCRIPTION
the meta tag:
`<meta name="apple-mobile-web-app-capable" content="yes" />`
was appearing twice
