### PR TITLE
Add support for building KeeWeb on Windows

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
     "singleQuote": true,
     "printWidth": 100,
     "trailingComma": "none",
-    "quoteProps": "preserve"
+    "quoteProps": "preserve",
+    "endOfLine": "auto"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,19 +3,24 @@
 const fs = require('fs-extra');
 const path = require('path');
 const debug = require('debug');
-const os = require('os');
 
 const webpackConfig = require('./build/webpack.config');
 const webpackConfigTest = require('./test/test.webpack.config');
 const pkg = require('./package.json');
 
+const skipCodeSigning = process.argv.some(arg => arg.startsWith('--no-sign'));
 let codeSignConfig;
-if (os.platform() === 'darwin') {
+
+if (!skipCodeSigning) {
     try {
         codeSignConfig = require('../keys/codesign');
     } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn('Code signing config missing - signing the macOS build will be skipped.');
+        throw new Error(
+            'Unable to load code signing config from ../keys/codesign.\n' +
+                'This is needed for production builds targeting macOS.\n' +
+                'For development builds, run with the `--no-sign` arg to skip code signing,\n' +
+                'e.g. `npm start -- --no-sign`'
+        );
     }
 }
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,12 +3,13 @@
 const fs = require('fs-extra');
 const path = require('path');
 const debug = require('debug');
+const grunt = require('grunt');
 
 const webpackConfig = require('./build/webpack.config');
 const webpackConfigTest = require('./test/test.webpack.config');
 const pkg = require('./package.json');
 
-const skipCodeSigning = process.argv.some(arg => arg.startsWith('--no-sign'));
+const skipCodeSigning = grunt.option('no-sign');
 let codeSignConfig;
 
 if (!skipCodeSigning) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,31 +3,30 @@
 const fs = require('fs-extra');
 const path = require('path');
 const debug = require('debug');
-const grunt = require('grunt');
 
 const webpackConfig = require('./build/webpack.config');
 const webpackConfigTest = require('./test/test.webpack.config');
 const pkg = require('./package.json');
 
-const skipCodeSigning = grunt.option('no-sign');
-let codeSignConfig;
-
-if (!skipCodeSigning) {
-    try {
-        codeSignConfig = require('../keys/codesign');
-    } catch (err) {
-        throw new Error(
-            'Unable to load code signing config from ../keys/codesign.\n' +
-                'This is needed for production builds targeting macOS.\n' +
-                'For development builds, run with the `--no-sign` arg to skip code signing,\n' +
-                'e.g. `npm start -- --no-sign`'
-        );
-    }
-}
-
 debug.enable('electron-notarize');
 
 module.exports = function(grunt) {
+    const skipCodeSigning = grunt.option('no-sign');
+    let codeSignConfig;
+
+    if (!skipCodeSigning) {
+        try {
+            codeSignConfig = require('../keys/codesign');
+        } catch (err) {
+            throw new Error(
+                'Unable to load code signing config from ../keys/codesign.\n' +
+                    'This is needed for production builds targeting macOS.\n' +
+                    'For development builds, run with the `--no-sign` arg to skip code signing,\n' +
+                    'e.g. `npm start -- --no-sign`'
+            );
+        }
+    }
+
     require('time-grunt')(grunt);
     require('load-grunt-tasks')(grunt);
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Desktop apps are built with `grunt desktop`. This works only in macOS as it buil
 Also, a hardware token is required.  
 To run Electron app without building an installer, build the app with `grunt` and start it this way:
 ```bash
-grunt dev
-npm run-script electron
+npm run dev
+npm run electron
 ```
 
 For debug build:
 
-1. run `grunt dev`
+1. run `npm run dev`
 2. open `http://localhost:8085`
 
 # Contributing

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -131,7 +131,7 @@ function config(options) {
                     ]
                 },
                 {
-                    test: /fonts\/.*\.(woff|ttf|eot|svg)$/,
+                    test: /fonts[\\/].*\.(woff|ttf|eot|svg)$/,
                     use: ['url-loader', 'ignore-loader']
                 },
                 { test: /\.woff2$/, loader: 'url-loader' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3435,6 +3435,52 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
     },
     "scripts": {
         "start": "grunt",
-        "test": "grunt test",
+        "test": "grunt test --no-sign",
         "postinstall": "cd desktop && npm install",
         "build-beta": "grunt --beta && cp dist/index.html ../keeweb-beta/index.html && cd ../keeweb-beta && git add index.html && git commit -a -m 'beta' && git push origin master",
         "electron": "cross-env ELECTRON_DISABLE_SECURITY_WARNINGS=1 electron desktop --htmlpath=http://localhost:8085",
-        "dev": "grunt dev",
+        "dev": "grunt dev --no-sign",
         "babel-helpers": "babel-external-helpers -l 'slicedToArray,toConsumableArray,defineProperty,typeof' -t global > app/lib/babel-helpers.js"
     },
     "author": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "base64-loader": "1.0.0",
         "bourbon": "^6.0.0",
         "chai": "^4.2.0",
+        "cross-env": "^6.0.3",
         "dompurify": "^2.0.7",
         "electron": "^7.0.0",
         "eslint": "^6.6.0",
@@ -95,7 +96,7 @@
         "test": "grunt test",
         "postinstall": "cd desktop && npm install",
         "build-beta": "grunt --beta && cp dist/index.html ../keeweb-beta/index.html && cd ../keeweb-beta && git add index.html && git commit -a -m 'beta' && git push origin master",
-        "electron": "ELECTRON_DISABLE_SECURITY_WARNINGS=1 electron desktop --htmlpath=http://localhost:8085",
+        "electron": "cross-env ELECTRON_DISABLE_SECURITY_WARNINGS=1 electron desktop --htmlpath=http://localhost:8085",
         "dev": "grunt dev",
         "babel-helpers": "babel-external-helpers -l 'slicedToArray,toConsumableArray,defineProperty,typeof' -t global > app/lib/babel-helpers.js"
     },


### PR DESCRIPTION
As the title suggests, it looks like this was once working but presumably Windows got left behind at some point 😄 

- Configured line ending settings in the Prettier config to "auto"
  - Without this, Prettier wants to convert everything to Unix line endings because it inherits that config from the `.editorconfig` - this causes linting to fail and therefore the `npm run dev` command doesn't work. The downside to this is that Prettier will no longer ensure all files use Unix line endings (it will only ensure that line endings are consistent within a file).
  - Since the repository doesn't include a `.gitattributes` file, files are checked out on Windows with CRLF line endings by default. However, any commits made on Windows will convert those files back to Unix (LF) line endings for git's internal representation of the files, when using git's default line endings config.
  - A proper fix would be to introduce a `.gitattributes` file containing `* text eol=lf` but this would require normalizing the line endings for all of the files in the repo
- Only try to load code signing config on macOS
- If loading the code signing config file fails, print a warning and carry on anyway
  - I can understand that it'd be useful to have this throw an error for non-dev builds, but I couldn't think of an easy way to detect this unless you run builds with code signing on a CI server (in which case you could check for a CI-specific environment variable, e.g. `if (process.env.CI) throw new Error(...)`)
- Fixed a regular expression in the Webpack config to support Windows path separators (backslashes)
- Fixed the `npm run electron` script to set an environment variable in a cross-platform way (using `cross-env`)