### PR TITLE
Make the app installable as PWA

### DIFF
--- a/app/manifest/manifest.json
+++ b/app/manifest/manifest.json
@@ -2,6 +2,7 @@
     "name": "KeeWeb",
     "short_name": "KeeWeb",
     "description": "Free cross-platform password manager compatible with KeePass",
+    "start_url": "./",
     "display": "standalone",
     "orientation": "any",
     "theme_color": "#6386ec",


### PR DESCRIPTION
In order to be installable as PWA, the app should have at least **start_url** property in the manifest.

To address https://github.com/keeweb/keeweb/issues/1360#issuecomment-582912644

Also checked with Lighthouse audit, no PWA blocking issues found.