### PR TITLE
Avoid handlebars update

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "grunt-inline-alt": "github:keeweb/grunt-inline-alt#ec9f6ad",
         "grunt-string-replace": "1.3.1",
         "grunt-webpack": "3.1.3",
-        "handlebars": "^4.4.5",
+        "handlebars": "4.4.5",
         "handlebars-loader": "1.7.1",
         "html-minifier": "4.0.0",
         "ignore-loader": "^0.1.2",


### PR DESCRIPTION
Hi @antelle,

If you delete `package-lock.json` and run `npm install`, `handlebars` library will be updated to the latest version: `4.7.3`.

This version doesn't work with `Keeweb`.
There is this error in the web browser console:
```
Handlebars: Access has been denied to resolve the property "length" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details
```
In `Keeweb`, all entries in the middle column are with label: `(no title)` and selection is not working.
It means you are not able to see `Keeweb` data.

Best regards,
CYOSP
