### PR TITLE
fix #1293 - copying website omits protocol 

### DIFF
--- a/app/scripts/views/fields/field-view.js
+++ b/app/scripts/views/fields/field-view.js
@@ -83,18 +83,30 @@ class FieldView extends View {
         let copyRes;
         if (field) {
             const value = this.value || '';
-            if (value && value.isProtected) {
-                const text = value.getText();
-                if (!text) {
+            if (value) {
+                if(value.isProtected){
+                    const text = value.getText();
+                    if (!text) {
+                        return;
+                    }
+                    if (!CopyPaste.simpleCopy) {
+                        CopyPaste.createHiddenInput(text);
+                    }
+                    copyRes = CopyPaste.copy(text);
+                    this.emit('copy', { source: this, copyRes });
                     return;
                 }
-                if (!CopyPaste.simpleCopy) {
-                    CopyPaste.createHiddenInput(text);
+            
+                if(field == "$URL"){
+                    if (!CopyPaste.simpleCopy) {
+                        CopyPaste.createHiddenInput(value);
+                    }
+                    copyRes = CopyPaste.copy(value);
+                    this.emit('copy', { source: this, copyRes });
+                    return;
+                
                 }
-                copyRes = CopyPaste.copy(text);
-                this.emit('copy', { source: this, copyRes });
-                return;
-            }
+            } 
         }
         if (!this.value) {
             return;


### PR DESCRIPTION
Fixes #1293 

Also, one thing i noticed is that when the website field is unfocused it doesn't show the protocol, but it only does this for https:// urls. All other protocols like http:// or ftp:// are shown, which seems a bit weird. 