### PR TITLE
Fixed auto-type on tiling wm

### DIFF
--- a/app/scripts/auto-type/auto-type-emitter-factory.js
+++ b/app/scripts/auto-type/auto-type-emitter-factory.js
@@ -1,14 +1,11 @@
 import { Launcher } from 'comp/launcher';
 
 const AutoTypeEmitterFactory = {
-    create(callback, windowID) {
+    create(callback, windowId) {
         if (Launcher && Launcher.autoTypeSupported) {
             const { AutoTypeEmitter } = require('./emitter/auto-type-emitter-' +
                 Launcher.platform());
-            if (Launcher.platform() === 'linux') {
-                return new AutoTypeEmitter(callback, windowID);
-            }
-            return new AutoTypeEmitter(callback);
+            return new AutoTypeEmitter(callback, windowId);
         }
         return null;
     }

--- a/app/scripts/auto-type/auto-type-emitter-factory.js
+++ b/app/scripts/auto-type/auto-type-emitter-factory.js
@@ -1,10 +1,13 @@
 import { Launcher } from 'comp/launcher';
 
 const AutoTypeEmitterFactory = {
-    create(callback) {
+    create(callback, windowID) {
         if (Launcher && Launcher.autoTypeSupported) {
             const { AutoTypeEmitter } = require('./emitter/auto-type-emitter-' +
                 Launcher.platform());
+            if (Launcher.platform() === 'linux') {
+                return new AutoTypeEmitter(callback, windowID);
+            }
             return new AutoTypeEmitter(callback);
         }
         return null;

--- a/app/scripts/auto-type/auto-type-parser.js
+++ b/app/scripts/auto-type/auto-type-parser.js
@@ -1,7 +1,8 @@
 import { AutoTypeRunner } from 'auto-type/auto-type-runner';
 
-const AutoTypeParser = function(sequence) {
+const AutoTypeParser = function(sequence, windowID) {
     this.sequence = sequence;
+    this.windowID = windowID;
     this.ix = 0;
     this.states = [];
 };
@@ -42,7 +43,7 @@ AutoTypeParser.prototype.parse = function() {
     if (this.states.length !== 1) {
         throw 'Groups count mismatch';
     }
-    return new AutoTypeRunner(this.state().ops);
+    return new AutoTypeRunner(this.state().ops, this.windowID);
 };
 
 AutoTypeParser.prototype.pushState = function() {

--- a/app/scripts/auto-type/auto-type-parser.js
+++ b/app/scripts/auto-type/auto-type-parser.js
@@ -1,8 +1,7 @@
 import { AutoTypeRunner } from 'auto-type/auto-type-runner';
 
-const AutoTypeParser = function(sequence, windowID) {
+const AutoTypeParser = function(sequence) {
     this.sequence = sequence;
-    this.windowID = windowID;
     this.ix = 0;
     this.states = [];
 };
@@ -43,7 +42,7 @@ AutoTypeParser.prototype.parse = function() {
     if (this.states.length !== 1) {
         throw 'Groups count mismatch';
     }
-    return new AutoTypeRunner(this.state().ops, this.windowID);
+    return new AutoTypeRunner(this.state().ops);
 };
 
 AutoTypeParser.prototype.pushState = function() {

--- a/app/scripts/auto-type/auto-type-runner.js
+++ b/app/scripts/auto-type/auto-type-runner.js
@@ -9,8 +9,9 @@ const emitterLogger = new Logger(
     localStorage.debugAutoType ? Logger.Level.All : Logger.Level.Warn
 );
 
-const AutoTypeRunner = function(ops) {
+const AutoTypeRunner = function(ops, windowID) {
     this.ops = ops;
+    this.windowID = windowID;
     this.pendingResolvesCount = 0;
     this.entry = null;
     this.now = new Date();
@@ -426,7 +427,7 @@ AutoTypeRunner.prototype.obfuscateOp = function(op) {
 };
 
 AutoTypeRunner.prototype.run = function(callback) {
-    this.emitter = AutoTypeEmitterFactory.create(this.emitNext.bind(this));
+    this.emitter = AutoTypeEmitterFactory.create(this.emitNext.bind(this), this.windowID);
     this.emitterState = {
         callback,
         stack: [],

--- a/app/scripts/auto-type/auto-type-runner.js
+++ b/app/scripts/auto-type/auto-type-runner.js
@@ -9,9 +9,8 @@ const emitterLogger = new Logger(
     localStorage.debugAutoType ? Logger.Level.All : Logger.Level.Warn
 );
 
-const AutoTypeRunner = function(ops, windowID) {
+const AutoTypeRunner = function(ops) {
     this.ops = ops;
-    this.windowID = windowID;
     this.pendingResolvesCount = 0;
     this.entry = null;
     this.now = new Date();
@@ -426,8 +425,8 @@ AutoTypeRunner.prototype.obfuscateOp = function(op) {
     op.type = 'group';
 };
 
-AutoTypeRunner.prototype.run = function(callback) {
-    this.emitter = AutoTypeEmitterFactory.create(this.emitNext.bind(this), this.windowID);
+AutoTypeRunner.prototype.run = function(callback, windowId) {
+    this.emitter = AutoTypeEmitterFactory.create(this.emitNext.bind(this), windowId);
     this.emitterState = {
         callback,
         stack: [],

--- a/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
+++ b/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
@@ -59,8 +59,9 @@ const ModMap = {
     '^^': 'ctrl'
 };
 
-const AutoTypeEmitter = function(callback) {
+const AutoTypeEmitter = function(callback, windowID) {
     this.callback = callback;
+    this.windowID = windowID;
     this.mod = {};
     this.pendingScript = [];
 };
@@ -76,13 +77,15 @@ AutoTypeEmitter.prototype.setMod = function(mod, enabled) {
 AutoTypeEmitter.prototype.text = function(text) {
     this.pendingScript.push('keyup ctrl alt shift t');
     Object.keys(this.mod).forEach(mod => {
-        this.pendingScript.push('keydown ' + ModMap[mod]);
+        this.pendingScript.push('keydown --window  ' + this.windowID + ' ' + ModMap[mod]);
     });
     text.split('').forEach(char => {
-        this.pendingScript.push('key U' + char.charCodeAt(0).toString(16));
+        this.pendingScript.push(
+            'key --window ' + this.windowID + ' U' + char.charCodeAt(0).toString(16)
+        );
     });
     Object.keys(this.mod).forEach(mod => {
-        this.pendingScript.push('keyup ' + ModMap[mod]);
+        this.pendingScript.push('keyup --window ' + this.windowID + ' ' + ModMap[mod]);
     });
     this.waitComplete();
 };
@@ -94,14 +97,16 @@ AutoTypeEmitter.prototype.key = function(key) {
         }
         key = KeyMap[key].toString(16);
     }
-    this.pendingScript.push('key --clearmodifiers ' + this.modString() + key);
+    this.pendingScript.push(
+        'key --clearmodifiers --window ' + this.windowID + ' ' + this.modString() + key
+    );
     this.callback();
 };
 
 AutoTypeEmitter.prototype.copyPaste = function(text) {
     this.pendingScript.push('sleep 0.5');
     Launcher.setClipboardText(text);
-    this.pendingScript.push('key --clearmodifiers shift+Insert');
+    this.pendingScript.push('key --clearmodifiers --window ' + this.windowID + ' shift+Insert');
     this.pendingScript.push('sleep 0.5');
     this.waitComplete();
 };

--- a/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
+++ b/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
@@ -59,9 +59,9 @@ const ModMap = {
     '^^': 'ctrl'
 };
 
-const AutoTypeEmitter = function(callback, windowID) {
+const AutoTypeEmitter = function(callback, windowId) {
     this.callback = callback;
-    this.windowID = windowID;
+    this.windowId = windowId;
     this.mod = {};
     this.pendingScript = [];
 };
@@ -77,15 +77,15 @@ AutoTypeEmitter.prototype.setMod = function(mod, enabled) {
 AutoTypeEmitter.prototype.text = function(text) {
     this.pendingScript.push('keyup ctrl alt shift t');
     Object.keys(this.mod).forEach(mod => {
-        this.pendingScript.push('keydown --window  ' + this.windowID + ' ' + ModMap[mod]);
+        this.pendingScript.push('keydown --window  ' + this.windowId + ' ' + ModMap[mod]);
     });
     text.split('').forEach(char => {
         this.pendingScript.push(
-            'key --window ' + this.windowID + ' U' + char.charCodeAt(0).toString(16)
+            'key --window ' + this.windowId + ' U' + char.charCodeAt(0).toString(16)
         );
     });
     Object.keys(this.mod).forEach(mod => {
-        this.pendingScript.push('keyup --window ' + this.windowID + ' ' + ModMap[mod]);
+        this.pendingScript.push('keyup --window ' + this.windowId + ' ' + ModMap[mod]);
     });
     this.waitComplete();
 };
@@ -98,7 +98,7 @@ AutoTypeEmitter.prototype.key = function(key) {
         key = KeyMap[key].toString(16);
     }
     this.pendingScript.push(
-        'key --clearmodifiers --window ' + this.windowID + ' ' + this.modString() + key
+        'key --clearmodifiers --window ' + this.windowId + ' ' + this.modString() + key
     );
     this.callback();
 };
@@ -106,7 +106,7 @@ AutoTypeEmitter.prototype.key = function(key) {
 AutoTypeEmitter.prototype.copyPaste = function(text) {
     this.pendingScript.push('sleep 0.5');
     Launcher.setClipboardText(text);
-    this.pendingScript.push('key --clearmodifiers --window ' + this.windowID + ' shift+Insert');
+    this.pendingScript.push('key --clearmodifiers --window ' + this.windowId + ' shift+Insert');
     this.pendingScript.push('sleep 0.5');
     this.waitComplete();
 };

--- a/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
+++ b/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
@@ -61,7 +61,11 @@ const ModMap = {
 
 const AutoTypeEmitter = function(callback, windowId) {
     this.callback = callback;
-    this.windowId = windowId;
+    if (typeof windowId !== 'undefined' && windowId) {
+        this.windowParameter = '--window ' + windowId + ' ';
+    } else {
+        this.windowParameter = '';
+    }
     this.mod = {};
     this.pendingScript = [];
 };
@@ -77,15 +81,15 @@ AutoTypeEmitter.prototype.setMod = function(mod, enabled) {
 AutoTypeEmitter.prototype.text = function(text) {
     this.pendingScript.push('keyup ctrl alt shift t');
     Object.keys(this.mod).forEach(mod => {
-        this.pendingScript.push('keydown --window  ' + this.windowId + ' ' + ModMap[mod]);
+        this.pendingScript.push('keydown ' + this.windowParameter + ModMap[mod]);
     });
     text.split('').forEach(char => {
         this.pendingScript.push(
-            'key --window ' + this.windowId + ' U' + char.charCodeAt(0).toString(16)
+            'key ' + this.windowParameter + 'U' + char.charCodeAt(0).toString(16)
         );
     });
     Object.keys(this.mod).forEach(mod => {
-        this.pendingScript.push('keyup --window ' + this.windowId + ' ' + ModMap[mod]);
+        this.pendingScript.push('keyup ' + this.windowParameter + ModMap[mod]);
     });
     this.waitComplete();
 };
@@ -98,7 +102,7 @@ AutoTypeEmitter.prototype.key = function(key) {
         key = KeyMap[key].toString(16);
     }
     this.pendingScript.push(
-        'key --clearmodifiers --window ' + this.windowId + ' ' + this.modString() + key
+        'key --clearmodifiers ' + this.windowParameter + this.modString() + key
     );
     this.callback();
 };
@@ -106,7 +110,7 @@ AutoTypeEmitter.prototype.key = function(key) {
 AutoTypeEmitter.prototype.copyPaste = function(text) {
     this.pendingScript.push('sleep 0.5');
     Launcher.setClipboardText(text);
-    this.pendingScript.push('key --clearmodifiers --window ' + this.windowId + ' shift+Insert');
+    this.pendingScript.push('key --clearmodifiers ' + this.windowParameter + 'shift+Insert');
     this.pendingScript.push('sleep 0.5');
     this.waitComplete();
 };

--- a/app/scripts/auto-type/index.js
+++ b/app/scripts/auto-type/index.js
@@ -79,7 +79,7 @@ const AutoType = {
         logger.debug('Start', sequence);
         const ts = logger.ts();
         try {
-            const parser = new AutoTypeParser(sequence, this.windowID);
+            const parser = new AutoTypeParser(sequence);
             const runner = parser.parse();
             logger.debug('Parsed', this.printOps(runner.ops));
             runner.resolve(result.entry, err => {
@@ -107,7 +107,7 @@ const AutoType = {
                     }
                     logger.debug('Complete', logger.ts(ts));
                     return callback && callback();
-                });
+                }, this.windowId);
             });
         } catch (ex) {
             this.running = false;
@@ -169,7 +169,6 @@ const AutoType = {
                     const urlMatches = urlMatcher.exec(windowInfo.title);
                     windowInfo.url = urlMatches && urlMatches.length > 0 ? urlMatches[0] : null;
                 }
-                this.windowID = windowInfo.id;
                 logger.debug('Window info', windowInfo.id, windowInfo.title, windowInfo.url);
             }
             return callback(err, windowInfo);
@@ -186,13 +185,14 @@ const AutoType = {
                 logger.debug('Error during active window check, something is wrong', err);
                 return callback(false);
             }
-            // if (activeWindowInfo.id !== windowInfo.id) {
-            //     logger.info(
-            //         `Active window doesn't match: ID is different. ` +
-            //             `Expected ${windowInfo.id}, got ${activeWindowInfo.id}`
-            //     );
-            //     return callback(false, activeWindowInfo);
-            // }
+            this.windowId = windowInfo.id;
+            if (activeWindowInfo.id !== windowInfo.id && Launcher.platform() !== 'linux') {
+                logger.info(
+                    `Active window doesn't match: ID is different. ` +
+                        `Expected ${windowInfo.id}, got ${activeWindowInfo.id}`
+                );
+                return callback(false, activeWindowInfo);
+            }
             if (activeWindowInfo.url !== windowInfo.url) {
                 logger.info(
                     `Active window doesn't match: url is different. ` +
@@ -200,7 +200,6 @@ const AutoType = {
                 );
                 return callback(false, activeWindowInfo);
             }
-            this.windowID = windowInfo.id;
             logger.info('Active window matches');
             callback(true, activeWindowInfo);
         });

--- a/app/scripts/auto-type/index.js
+++ b/app/scripts/auto-type/index.js
@@ -79,7 +79,7 @@ const AutoType = {
         logger.debug('Start', sequence);
         const ts = logger.ts();
         try {
-            const parser = new AutoTypeParser(sequence);
+            const parser = new AutoTypeParser(sequence, this.windowID);
             const runner = parser.parse();
             logger.debug('Parsed', this.printOps(runner.ops));
             runner.resolve(result.entry, err => {
@@ -169,6 +169,7 @@ const AutoType = {
                     const urlMatches = urlMatcher.exec(windowInfo.title);
                     windowInfo.url = urlMatches && urlMatches.length > 0 ? urlMatches[0] : null;
                 }
+                this.windowID = windowInfo.id;
                 logger.debug('Window info', windowInfo.id, windowInfo.title, windowInfo.url);
             }
             return callback(err, windowInfo);
@@ -185,13 +186,13 @@ const AutoType = {
                 logger.debug('Error during active window check, something is wrong', err);
                 return callback(false);
             }
-            if (activeWindowInfo.id !== windowInfo.id) {
-                logger.info(
-                    `Active window doesn't match: ID is different. ` +
-                        `Expected ${windowInfo.id}, got ${activeWindowInfo.id}`
-                );
-                return callback(false, activeWindowInfo);
-            }
+            // if (activeWindowInfo.id !== windowInfo.id) {
+            //     logger.info(
+            //         `Active window doesn't match: ID is different. ` +
+            //             `Expected ${windowInfo.id}, got ${activeWindowInfo.id}`
+            //     );
+            //     return callback(false, activeWindowInfo);
+            // }
             if (activeWindowInfo.url !== windowInfo.url) {
                 logger.info(
                     `Active window doesn't match: url is different. ` +
@@ -199,6 +200,7 @@ const AutoType = {
                 );
                 return callback(false, activeWindowInfo);
             }
+            this.windowID = windowInfo.id;
             logger.info('Active window matches');
             callback(true, activeWindowInfo);
         });

--- a/app/scripts/auto-type/index.js
+++ b/app/scripts/auto-type/index.js
@@ -58,8 +58,8 @@ const AutoType = {
         }
     },
 
-    runAndHandleResult(result) {
-        this.run(result, err => {
+    runAndHandleResult(result, windowId) {
+        this.run(result, windowId, err => {
             if (err) {
                 Alerts.error({
                     header: Locale.autoTypeError,
@@ -73,7 +73,7 @@ const AutoType = {
         }
     },
 
-    run(result, callback) {
+    run(result, windowId, callback) {
         this.running = true;
         const sequence = result.sequence || result.entry.getEffectiveAutoTypeSeq();
         logger.debug('Start', sequence);
@@ -107,7 +107,7 @@ const AutoType = {
                     }
                     logger.debug('Complete', logger.ts(ts));
                     return callback && callback();
-                }, this.windowId);
+                }, windowId);
             });
         } catch (ex) {
             this.running = false;
@@ -185,7 +185,6 @@ const AutoType = {
                 logger.debug('Error during active window check, something is wrong', err);
                 return callback(false);
             }
-            this.windowId = windowInfo.id;
             if (activeWindowInfo.id !== windowInfo.id && Launcher.platform() !== 'linux') {
                 logger.info(
                     `Active window doesn't match: ID is different. ` +
@@ -227,7 +226,7 @@ const AutoType = {
         const entries = evt.filter.getEntries();
         if (entries.length === 1 && AppSettingsModel.directAutotype) {
             this.hideWindow(() => {
-                this.runAndHandleResult({ entry: entries[0] });
+                this.runAndHandleResult({ entry: entries[0] }, evt.windowInfo.id);
             });
             return;
         }
@@ -243,7 +242,7 @@ const AutoType = {
                 if (result) {
                     this.activeWindowMatches(evt.windowInfo, (matches, activeWindowInfo) => {
                         if (matches) {
-                            this.runAndHandleResult(result);
+                            this.runAndHandleResult(result, evt.windowInfo.id);
                         }
                     });
                 }


### PR DESCRIPTION
Fix for issue with auto-type on a tiling window manager.
Grunt passes without errors, tested browser version (Not affected by changes) and desktop version (On linux & windows, macos shouldn't be any different from windows)

- The id for the window that was active at the time of pressing the hotkey gets passed to auto-type-emitter-linux.js where it is passed as an argument to xdotool, which causes the tool to send the keystrokes directly to the desired window, regardless of the active window.
- The window id only gets passed to the emitter if the platform is linux, the code for other platforms was not modified and should therefore work just as before.
- In index.js I commented out an if statement testing whether or not the active window id before selecting a login in keeweb was the same afterwards. Maybe this statement should be put back in and only throw an error if the tool for simulating keystrokes does not support sending those to a specific window.