### PR TITLE
Added check for platform before calling app.dock

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -609,7 +609,7 @@ function deleteRecursive(dir) {
 }
 
 function setDevAppIcon() {
-    if (isDev && htmlPath) {
+    if (isDev && htmlPath && process.platform === 'darwin') {
         const icon = electron.nativeImage.createFromPath(
             path.join(__dirname, '../graphics/512x512.png')
         );


### PR DESCRIPTION
`npm run electron` throws an error on linux/windows, this is due to calling app.dock.setIcon() without checking for the platform first (Native to darwin, all other occurrences of app.dock check for platform first).
Here is the original error message:

> TypeError: Cannot read property 'setIcon' of undefined
>     at setDevAppIcon (C:\Users\Benjamin\Desktop\keeweb\desktop\app.js:616:18)
>     at Object.<anonymous> (C:\Users\Benjamin\Desktop\keeweb\desktop\app.js:64:1)
>     at Module._compile (internal/modules/cjs/loader.js:968:30)
>     at Object.Module._extensions..js (internal/modules/cjs/loader.js:986:10)
>     at Module.load (internal/modules/cjs/loader.js:816:32)
>     at Module._load (internal/modules/cjs/loader.js:728:14)
>     at Module._load (electron/js2c/asar.js:717:26)
>     at Function.Module._load (electron/js2c/asar.js:717:26)
>     at Module.require (internal/modules/cjs/loader.js:853:19)
>     at require (internal/modules/cjs/helpers.js:74:18)

Tested this fix on linux, should work on windows & macos as well.