### PR TITLE
Fix quitting the app when not minimized and window is closed

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -126,7 +126,7 @@ app.on('activate', () => {
     }
 });
 app.on('before-quit', (e) => {
-    if (app.hookBeforeQuitEvent) {
+    if (app.hookBeforeQuitEvent && mainWindow) {
         e.preventDefault();
         emitRemoteEvent('launcher-before-quit');
     }


### PR DESCRIPTION
On MacOS when the main window is closed (with "minimize" feature disabled) it is impossible to Quit the app from the Dock or otherwise (expect for Force Quit). The only way to Quit normally is to open the app again and then Quit from the Dock.

The major issue is that is hangs system reboot as the system can't Quit the app, so every reboot requires user interaction and manual Force Quit of the app.

The primary cause should be the fact that the `before-quit` callback is replaced with a hook which in turn is invoked through an event but event handling (in this case at least) is not possible without the main window. 