### PR TITLE
use windowactivate via xdotool

### DIFF
--- a/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
+++ b/app/scripts/auto-type/emitter/auto-type-emitter-linux.js
@@ -61,13 +61,11 @@ const ModMap = {
 
 const AutoTypeEmitter = function (callback, windowId) {
     this.callback = callback;
-    if (typeof windowId !== 'undefined' && windowId) {
-        this.windowParameter = '--window ' + windowId + ' ';
-    } else {
-        this.windowParameter = '';
-    }
     this.mod = {};
     this.pendingScript = [];
+    if (typeof windowId !== 'undefined' && windowId) {
+        this.pendingScript.push('windowactivate --sync ' + windowId);
+    }
 };
 
 AutoTypeEmitter.prototype.setMod = function (mod, enabled) {
@@ -81,15 +79,15 @@ AutoTypeEmitter.prototype.setMod = function (mod, enabled) {
 AutoTypeEmitter.prototype.text = function (text) {
     this.pendingScript.push('keyup ctrl alt shift t');
     Object.keys(this.mod).forEach((mod) => {
-        this.pendingScript.push('keydown ' + this.windowParameter + ModMap[mod]);
+        this.pendingScript.push('keydown ' + ModMap[mod]);
     });
     text.split('').forEach((char) => {
         this.pendingScript.push(
-            'key ' + this.windowParameter + 'U' + char.charCodeAt(0).toString(16)
+            'key ' + 'U' + char.charCodeAt(0).toString(16)
         );
     });
     Object.keys(this.mod).forEach((mod) => {
-        this.pendingScript.push('keyup ' + this.windowParameter + ModMap[mod]);
+        this.pendingScript.push('keyup ' + ModMap[mod]);
     });
     this.waitComplete();
 };
@@ -103,7 +101,7 @@ AutoTypeEmitter.prototype.key = function (key) {
         key = KeyMap[key].toString();
     }
     this.pendingScript.push(
-        'key --clearmodifiers ' + this.windowParameter + this.modString() + key
+        'key --clearmodifiers ' + this.modString() + key
     );
     if (isSpecialKey) {
         this.waitComplete();
@@ -115,7 +113,7 @@ AutoTypeEmitter.prototype.key = function (key) {
 AutoTypeEmitter.prototype.copyPaste = function (text) {
     this.pendingScript.push('sleep 0.5');
     Launcher.setClipboardText(text);
-    this.pendingScript.push('key --clearmodifiers ' + this.windowParameter + 'shift+Insert');
+    this.pendingScript.push('key --clearmodifiers ' + 'shift+Insert');
     this.pendingScript.push('sleep 0.5');
     this.waitComplete();
 };


### PR DESCRIPTION
I'm making this PR against `master` since that is where I'm having issues. This PR only changes the use of `xdotool` in the linux auto-type emitter, but using `windowactivate` to bring the window up. With these changes auto-type on LInux succeeds again both with `alt-shift-t` and `ctrl-t`.

I was unable to run the linting correctly and so I uncommented that to allow me to implement this hotfix.

This is a single file change only and impacts only the linux platform.

This resolves issue #1564