### PR TITLE
Clean up apt local cache in Dockerfile

### DIFF
--- a/package/docker-rpi/Dockerfile
+++ b/package/docker-rpi/Dockerfile
@@ -31,7 +31,7 @@ RUN sed -i 's/access_log.*/access_log \/dev\/stdout;/g' /etc/nginx/nginx.conf; \
     sed -i 's/error_log.*/error_log \/dev\/stdout info;/g' /etc/nginx/nginx.conf; \
     sed -i 's/error_log \/dev\/stdout info;/error_log \/dev\/stdout info;\n\n# daemon mode off\ndaemon off;/g' /etc/nginx/nginx.conf
 
-ADD keeweb.conf /etc/nginx/conf.d/keeweb.conf
+COPY keeweb.conf /etc/nginx/conf.d/keeweb.conf
 
 # clone keeweb
 RUN wget https://github.com/keeweb/keeweb/archive/gh-pages.zip; \
@@ -46,7 +46,7 @@ RUN wget https://github.com/keeweb/keeweb-plugins/archive/master.zip; \
     mv keeweb-plugins-master/docs keeweb/plugins; \
     rm -rf keeweb-plugins-master;
 
-ADD entrypoint.sh /opt/entrypoint.sh
+COPY entrypoint.sh /opt/entrypoint.sh
 RUN chmod a+x /opt/entrypoint.sh
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -27,13 +27,13 @@ RUN sed -i 's/access_log.*/access_log \/dev\/stdout;/g' /etc/nginx/nginx.conf; \
     sed -i 's/error_log.*/error_log \/dev\/stdout info;/g' /etc/nginx/nginx.conf; \
     sed -i 's/^pid/daemon off;\npid/g' /etc/nginx/nginx.conf
 
-ADD keeweb.conf /etc/nginx/conf.d/keeweb.conf
+COPY keeweb.conf /etc/nginx/conf.d/keeweb.conf
 
-ADD entrypoint.sh /opt/entrypoint.sh
+COPY entrypoint.sh /opt/entrypoint.sh
 RUN chmod a+x /opt/entrypoint.sh
 
 # add keeweb files
-ADD dist keeweb
+COPY dist keeweb
 
 # clone keeweb plugins
 RUN curl -Ss -L -O https://github.com/keeweb/keeweb-plugins/archive/master.zip; \


### PR DESCRIPTION
Reference:

- docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

> For other items (files, directories) that do not require ADD’s tar auto-extraction capability, you should always use COPY.