### PR TITLE
redirect with original port in nginx config

### DIFF
--- a/package/docker/keeweb.conf
+++ b/package/docker/keeweb.conf
@@ -31,5 +31,5 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
     server_name _;
-    return 301 https://$host$request_uri;
+    return 301 https://$http_host$request_uri;
 }


### PR DESCRIPTION
Using the docker image latest.
Keeweb config is enforced via env var **KEEWEB_CONFIG_URL** to "config.json"

With a custom SSL port (i.e. 8443) does not correctly redirect 80 > 8443.

Nginx conf vars:
- `$host only` > redirects with original host name only.
- `$http_host` > redirects with original host name + original port.

Tested and working.

If merging, please ping back when a new docker image is published, as I need to remove my custom nginx conf volume mount.
