### PR TITLE
fix(docker): publish all docker image tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -354,7 +354,7 @@ jobs:
         run: docker tag antelle/keeweb:latest antelle/keeweb:${{ steps.get_tag.outputs.tag }}
       - name: Push the Docker image to the registry
         if: ${{ github.repository == 'keeweb/keeweb' }}
-        run: docker push antelle/keeweb
+        run: docker push --all-tags antelle/keeweb
       - name: Create a GitHub release
         id: create_release
         uses: actions/create-release@latest


### PR DESCRIPTION
As you can see in https://hub.docker.com/r/antelle/keeweb/tags?page=1&ordering=last_updated, tagged releases are not pushed since >3 months now. This fix will restore the functionality.