### PR TITLE
[RFC] Chrome extension for form fill

### DIFF
--- a/chrome/app-extension.js
+++ b/chrome/app-extension.js
@@ -1,0 +1,20 @@
+window.port = chrome.runtime.connect();
+window.port.onMessage.addListener(msg => {
+   window.postMessage(msg);
+});
+
+window.port.onDisconnect.addListener(() => {
+   console.log('app-extension.disconnect');
+   setTimeout(() => location.reload(), 1000);
+});
+
+window.addEventListener('message', event => {
+   console.log('app-extension.message', event);
+
+   // only accept messages from the same frame
+   if (event.source !== window) {
+      return;
+   }
+
+   window.port.postMessage(event.data);
+});

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,0 +1,28 @@
+let keewebPort;
+
+chrome.runtime.onMessage.addListener(
+   function(request, sender, sendResponse) {
+      console.log('onMessage', request);
+      if (request.type == 'get-creds') {
+         if (keewebPort) {
+            keewebPort.postMessage(request);
+         }
+      }
+   }
+);
+
+chrome.runtime.onConnect.addListener(port => {
+   console.log('onConnect');
+   keewebPort = port;
+
+   port.onMessage.addListener(msg => {
+      console.log('port.onMessage', msg);
+      if (msg.type == 'creds') {
+         chrome.runtime.sendMessage(msg);
+      }
+   });
+
+   port.onDisconnect.addListener(() => {
+      console.log('port.onDisconnect');
+   });
+});

--- a/chrome/login-extension.js
+++ b/chrome/login-extension.js
@@ -1,0 +1,6 @@
+chrome.runtime.onMessage.addListener(
+   function(message, sender, sendResponse) {
+      document.getElementById('login_field').value = message.username;
+      document.getElementById('password').value = message.password;
+   }
+);

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,0 +1,21 @@
+{
+   "name": "Keeweb Autofill",
+   "version": "1.0",
+   "manifest_version": 3,
+   "permissions": ["activeTab", "scripting"],
+   "action": {
+      "default_popup": "popup.html"
+   },
+   "background": {
+      "service_worker": "background.js"
+   },
+   "content_scripts": [
+      {
+         "matches": ["http://localhost:8085/"],
+         "js": ["app-extension.js"]
+      }
+   ],
+   "externally_connectable": {
+      "matches": ["http://localhost:8085/"]
+   }
+}

--- a/chrome/popup.css
+++ b/chrome/popup.css
@@ -1,0 +1,3 @@
+#tab-creds {
+   display: none;
+}

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+   <head>
+      <link rel="stylesheet" href="popup.css">
+   </head>
+   <body>
+      <div id="search">
+         <input type="text" id="search-input" placeholder="Search">
+      </div>
+      <div id="tab-creds">
+         <span></span>
+         <button>Fill</button>
+      </div>
+
+      <script src="popup.js"></script>
+   </body>
+</html>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -1,0 +1,59 @@
+function bind(obj) {
+   for (const selector in obj) {
+      for (const target in obj[selector]) {
+         const elem = document.querySelector(selector);
+         if (target == 'text') {
+            elem.textContent = obj[selector][target];
+         } else if (target == 'click') {
+            elem.addEventListener(target, obj[selector][target]);
+         }
+      }
+   }
+}
+
+class AutofillPopup {
+   constructor() {
+      chrome.runtime.onMessage.addListener((request, sender, sendResponse) =>
+         this.messageHandler(request, sender, sendResponse));
+   }
+
+   onLoad() {
+      chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+         this.tab = tabs[0];
+         chrome.runtime.sendMessage({type: 'get-creds', url: this.tab.url});
+      });
+   }
+
+   messageHandler(request, sender, sendResponse) {
+      if (request.type == 'creds') {
+         this.creds = request;
+         this.renderTabCreds();
+      }
+   }
+
+   renderTabCreds() {
+      let elem = document.getElementById('tab-creds');
+      elem.style.display = 'block';
+
+      bind({
+         '#tab-creds span': {
+            text: this.creds.username
+         },
+         '#tab-creds button': {
+            click: () => this.injectCreds()
+         }
+      });
+   }
+
+   injectCreds() {
+      chrome.scripting.executeScript({
+         target: {tabId: this.tab.id},
+         files: ['login-extension.js']
+      }, () => {
+         chrome.tabs.sendMessage(this.tab.id, this.creds);
+      });
+   }
+}
+
+let popop = new AutofillPopup();
+popop.onLoad();


### PR DESCRIPTION
For starters, apologies if a PR is the wrong way to start this conversation.

This is a bare bones POC chrome extension to populate login forms by connecting to a tab with keeweb loaded. What works now? When keyweb database is open, the extension can fill the login form for github (that's pretty much it).

I wanted to get some feedback, namely:
1. Is this something the user community is interested in getting? I'm planning to finish this for my personal use, but curious if others would find this useful.
2. Would this get integrated upstream in keeweb repo, or would it be best suited in a separate repo.
3. And I suppose building on question 2, the hacking I've done here to `app-model.js` is obviously not a final solution. I could see this going one of two ways:
3.1. Extension related code stays in keeweb core but gets abstracted into a module of some sort.
3.2. Extension related code is move to a plugin. I haven't fully wrapped my head around how plugins work so I'm curious to hear comments on this approach.
