### PR TITLE
Fix broken links to download the KeeWeb Connect browser extension

### DIFF
--- a/app/scripts/views/settings/settings-browser-view.js
+++ b/app/scripts/views/settings/settings-browser-view.js
@@ -57,7 +57,7 @@ class SettingsBrowserView extends View {
         } else {
             const extensionBrowserFamily = Features.extensionBrowserFamily;
             data.extensionBrowserFamily = Features.extensionBrowserFamily;
-            data.extensionDownloadLink = Links[`KeeWebConnectFor${extensionBrowserFamily}`];
+            data.extensionDownloadLink = Links[`KWCFor${extensionBrowserFamily}`];
         }
         super.render(data);
     }


### PR DESCRIPTION
Firstly - love the new KeeWeb Connect extension - awesome work 👍 

I noted under https://app.keeweb.info/ - the link to take the user to the extension download pages for each browser type (Chrome/Firefox/etc.) is currently broken with a blank `href=""`. Digging in, noted the `const/Links` property it's after is incorrect. This fixes that behaviour.

![Screen Shot 2021-06-05 at 3 15 25 pm](https://user-images.githubusercontent.com/1818757/120880947-e6ddbd00-c610-11eb-9ca5-876a06c46bb9.png)
