### PR TITLE
added teams storage; added tenant id configuration for microsot

### DIFF
--- a/app/content/oauth-result/teams.html
+++ b/app/content/oauth-result/teams.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>KeeWeb</title>
+    </head>
+    <body>
+        <script>
+            window.opener.postMessage(
+                { storage: 'teams', search: location.search },
+                window.location.origin
+            );
+            window.close();
+        </script>
+    </body>
+</html>

--- a/app/scripts/const/default-app-settings.js
+++ b/app/scripts/const/default-app-settings.js
@@ -87,7 +87,13 @@ const DefaultAppSettings = {
 
     onedrive: true, // enable OneDrive integration
     onedriveClientId: null, // custom OneDrive client id
-    onedriveClientSecret: null // custom OneDrive client secret
+    onedriveClientSecret: null, // custom OneDrive client secret
+    onedriveTenantId: null, // custom OneDrive tenant id
+
+    teams: true, // enable Teams integration
+    teamsClientId: null, // custom Teams client id
+    teamsClientSecret: null, // custom Teams client secret
+    teamsTenantId: null // custom Teams tenant id
 };
 
 export { DefaultAppSettings };

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -43,7 +43,7 @@
   "dropbox": "Dropbox",
   "gdrive": "Google Drive",
   "onedrive": "OneDrive",
-  "teams": "Teams",
+  "teams": "Microsoft Teams",
   "menuAllItems": "All Items",
   "menuColors": "Colors",
   "menuTrash": "Trash",

--- a/app/scripts/locales/base.json
+++ b/app/scripts/locales/base.json
@@ -43,6 +43,7 @@
   "dropbox": "Dropbox",
   "gdrive": "Google Drive",
   "onedrive": "OneDrive",
+  "teams": "Teams",
   "menuAllItems": "All Items",
   "menuColors": "Colors",
   "menuTrash": "Trash",

--- a/app/scripts/storage/impl/storage-onedrive.js
+++ b/app/scripts/storage/impl/storage-onedrive.js
@@ -229,7 +229,11 @@ class StorageOneDrive extends StorageBase {
             } else if (Features.isLocal) {
                 ({ id: clientId, secret: clientSecret, tenantId: tenant } = OneDriveApps.Local);
             } else {
-                ({ id: clientId, secret: clientSecret, tenantId: tenant } = OneDriveApps.Production);
+                ({
+                    id: clientId,
+                    secret: clientSecret,
+                    tenantId: tenant
+                } = OneDriveApps.Production);
             }
         }
         tenant = tenant || 'common';

--- a/app/scripts/storage/index.js
+++ b/app/scripts/storage/index.js
@@ -5,6 +5,7 @@ import { StorageFile } from 'storage/impl/storage-file';
 import { StorageFileCache } from 'storage/impl/storage-file-cache';
 import { StorageGDrive } from 'storage/impl/storage-gdrive';
 import { StorageOneDrive } from 'storage/impl/storage-onedrive';
+import { StorageTeams } from 'storage/impl/storage-teams';
 import { StorageWebDav } from 'storage/impl/storage-webdav';
 import { createOAuthSession } from 'storage/pkce';
 
@@ -17,6 +18,7 @@ const ThirdPartyStorage = {
     dropbox: new StorageDropbox(),
     gdrive: new StorageGDrive(),
     onedrive: new StorageOneDrive(),
+    teams: new StorageTeams(),
     webdav: new StorageWebDav()
 };
 

--- a/app/styles/base/_icon-font.scss
+++ b/app/styles/base/_icon-font.scss
@@ -82,6 +82,7 @@ $fa-var-file-image: next-fa-glyph();
 $fa-var-file-video: next-fa-glyph();
 $fa-var-file-audio: next-fa-glyph();
 $fa-var-onedrive: next-fa-glyph();
+$fa-var-user-friends: next-fa-glyph();
 $fa-var-question: next-fa-glyph();
 $fa-var-sign-out-alt: next-fa-glyph();
 $fa-var-sync-alt: next-fa-glyph();


### PR DESCRIPTION
- added teams storage
- added tenant id configuration for onedrive and teams

The code was tested to browse and open. Haven't tested to write.

Linked to issue #1265 

Adds new requirements to the Azure Active Directory Configuration:
- Permission:
  - Sites.ReadWrite.All
  - Team.ReadBasic.All
- Redirect URL:
  - https://HOSTNAME/oauth-result/teams.html (MUST ALSO BE ADDED TO THE SHARED TENANT)

Known issues:
- not able to return to the list of Teams
- Code could be merged with onedrive once the API is the same but would need some abstraction.
