### PR TITLE
Fixed issue with Csv parser parse (#1904)

### DIFF
--- a/app/scripts/util/data/csv-parser.js
+++ b/app/scripts/util/data/csv-parser.js
@@ -12,7 +12,7 @@ class CsvParser {
         this.result = [];
         this.next = this.handleBeforeValue;
         this.index = 0;
-        while (this.next && this.index < this.csv.length) {
+        while (this.next && this.index <= this.csv.length) {
             this.next = this.next(this);
         }
         if (this.lines.length <= 1) {


### PR DESCRIPTION
Thanks for taking the time to contribute! :gift:

I have fixed the issue with CSV import ignoring the last entry as mentioned in issue (#1904). This bug was there because the parse method in csv-parser method was using (<) condition instead of (<=) that's why the last line is always ignored. So I fixed it by updating the check condition.