### PR TITLE
Use Wayland backend for Wayland sessions

### DIFF
--- a/package/deb/usr/bin/keeweb
+++ b/package/deb/usr/bin/keeweb
@@ -1,2 +1,6 @@
 #!/bin/bash
-/usr/share/keeweb-desktop/keeweb "$@"
+if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+    /usr/share/keeweb-desktop/keeweb --enable-features=UseOzonePlatform --ozone-platform=wayland "$@"
+else
+    /usr/share/keeweb-desktop/keeweb "$@"
+fi


### PR DESCRIPTION
These two flags tell Electron, through Chromium, to use Wayland for rendering. The flags are set in the bash script, because setting them in desktop/main.js causes issues with rendering.

Rendering with Wayland instead of X11 and XWayland gives better support for DPI scaling. Additionally, this change also has implications for drag-and-drop, since drag-and-drop does not work consistently from XWayland to Wayland apps and visa versa (for example, from XWayland KeeWeb to Wayland Firefox under sway).