### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/app/scripts/comp/app/online-password-checker.js
+++ b/app/scripts/comp/app/online-password-checker.js
@@ -20,11 +20,11 @@ function checkIfPasswordIsExposedOnline(password) {
         .then((sha1) => {
             kdbxweb.ByteUtils.zeroBuffer(passwordBytes);
             sha1 = kdbxweb.ByteUtils.bytesToHex(sha1).toUpperCase();
-            const shaFirst = sha1.substr(0, 5);
+            const shaFirst = sha1.slice(0, 5);
             return fetch(`https://api.pwnedpasswords.com/range/${shaFirst}`)
                 .then((response) => response.text())
                 .then((response) => {
-                    const isPresent = response.includes(sha1.substr(5));
+                    const isPresent = response.includes(sha1.slice(5));
                     exposedPasswords[saltedValue] = isPresent;
                     return isPresent;
                 });

--- a/app/scripts/framework/views/view.js
+++ b/app/scripts/framework/views/view.js
@@ -114,8 +114,8 @@ class View extends EventEmitter {
             const spaceIx = eventDef.indexOf(' ');
             let event, selector;
             if (spaceIx > 0) {
-                event = eventDef.substr(0, spaceIx);
-                selector = eventDef.substr(spaceIx + 1);
+                event = eventDef.slice(0, spaceIx);
+                selector = eventDef.slice(spaceIx + 1);
                 if (DoesNotBubble[event]) {
                     this.elementEventListeners.push({ event, selector, method, els: [] });
                     continue;

--- a/app/scripts/hbs-helpers/res.js
+++ b/app/scripts/hbs-helpers/res.js
@@ -15,7 +15,7 @@ Handlebars.registerHelper('res', function (key, options) {
 Handlebars.registerHelper('Res', (key, options) => {
     let value = Locale[key];
     if (value) {
-        value = value[0].toUpperCase() + value.substr(1);
+        value = value[0].toUpperCase() + value.slice(1);
         const ix = value.indexOf('{}');
         if (ix >= 0) {
             value = value.replace('{}', options.fn(this));

--- a/app/scripts/models/entry-model.js
+++ b/app/scripts/models/entry-model.js
@@ -273,7 +273,7 @@ class EntryModel extends Model {
     _getReferenceValue(fieldRefId, idStr) {
         const id = new Uint8Array(16);
         for (let i = 0; i < 16; i++) {
-            id[i] = parseInt(idStr.substr(i * 2, 2), 16);
+            id[i] = parseInt(idStr.slice(i * 2, i * 2 + 2), 16);
         }
         const uuid = new kdbxweb.KdbxUuid(id);
         const entry = this.file.getEntry(this.file.subId(uuid.id));

--- a/app/scripts/plugins/theme-vars.js
+++ b/app/scripts/plugins/theme-vars.js
@@ -32,7 +32,7 @@ const ThemeVars = {
                 // definitions are written like this:
                 //      map-merge((def:val, def:val, ..., last-def:val),$t)
                 // so, the last item has "),$" captured, here we're removing that bracket
-                def = def.substr(0, def.length - 1);
+                def = def.slice(0, -1);
             }
             const propName = '--' + name;
             const currentValue = cssStyle.getPropertyValue(propName);
@@ -78,7 +78,7 @@ const ThemeVars = {
             }
         }
         if (/^L/.test(arg)) {
-            return locals[arg.substr(1)];
+            return locals[arg.slice(1)];
         }
         if (/%$/.test(arg)) {
             return arg.replace(/%$/, '') / 100;

--- a/app/scripts/storage/impl/storage-dropbox.js
+++ b/app/scripts/storage/impl/storage-dropbox.js
@@ -30,9 +30,9 @@ class StorageDropbox extends StorageBase {
         if (rootFolder) {
             const ix = path.toLowerCase().indexOf(rootFolder.toLowerCase());
             if (ix === 0) {
-                path = path.substr(rootFolder.length);
+                path = path.slice(rootFolder.length);
             } else if (ix === 1) {
-                path = path.substr(rootFolder.length + 1);
+                path = path.slice(rootFolder.length + 1);
             }
             path = UrlFormat.fixSlashes('/' + path);
         }
@@ -42,7 +42,7 @@ class StorageDropbox extends StorageBase {
     _fixConfigFolder(folder) {
         folder = folder.replace(/\\/g, '/').trim();
         if (folder[0] === '/') {
-            folder = folder.substr(1);
+            folder = folder.slice(1);
         }
         return folder;
     }

--- a/app/scripts/storage/impl/storage-webdav.js
+++ b/app/scripts/storage/impl/storage-webdav.js
@@ -397,7 +397,7 @@ class StorageWebDav extends StorageBase {
             return null;
         }
         return kdbxweb.CryptoEngine.sha256(xhr.response).then((hash) => {
-            const rev = kdbxweb.ByteUtils.bytesToHex(hash).substr(0, 10);
+            const rev = kdbxweb.ByteUtils.bytesToHex(hash).slice(0, 10);
             this.logger.debug('Calculated rev by content', `${xhr.response.byteLength} bytes`, rev);
             return { rev };
         });

--- a/app/scripts/util/data/color.js
+++ b/app/scripts/util/data/color.js
@@ -15,9 +15,9 @@ const Color = function (arg) {
         if (hexMatch) {
             const digits = hexMatch[1];
             const len = digits.length === 3 ? 1 : 2;
-            this.r = parseInt(digits.substr(0, len), 16);
-            this.g = parseInt(digits.substr(len, len), 16);
-            this.b = parseInt(digits.substr(len * 2, len), 16);
+            this.r = parseInt(digits.slice(0, len), 16);
+            this.g = parseInt(digits.slice(len, len * 2), 16);
+            this.b = parseInt(digits.slice(len * 2, len * 3), 16);
             this.a = 1;
             this.setHsl();
         } else if (arg instanceof Color) {

--- a/app/scripts/util/data/csv-parser.js
+++ b/app/scripts/util/data/csv-parser.js
@@ -44,7 +44,7 @@ class CsvParser {
             nextIndex = this.csv.length;
         }
 
-        const value = this.csv.substr(this.index, nextIndex - this.index);
+        const value = this.csv.slice(this.index, nextIndex);
         this.line.push(value);
 
         this.index = nextIndex;
@@ -66,23 +66,23 @@ class CsvParser {
             const charAfterBackslash = this.csv[nextBackslashIndex + 1];
             if (charAfterBackslash === '"' || charAfterBackslash === '\\') {
                 this.value +=
-                    this.csv.substr(this.index, nextBackslashIndex - this.index) +
+                    this.csv.slice(this.index, nextBackslashIndex) +
                     charAfterBackslash;
                 this.index = nextBackslashIndex + 2;
             } else {
-                this.value += this.csv.substr(this.index, nextBackslashIndex - this.index + 1);
+                this.value += this.csv.slice(this.index, nextBackslashIndex + 1);
                 this.index = nextBackslashIndex + 1;
             }
             return this.handleQuotedValue;
         }
 
         if (this.csv[nextQuoteIndex + 1] === '"') {
-            this.value += this.csv.substr(this.index, nextQuoteIndex - this.index + 1);
+            this.value += this.csv.slice(this.index, nextQuoteIndex + 1);
             this.index = nextQuoteIndex + 2;
             return this.handleQuotedValue;
         }
 
-        this.value += this.csv.substr(this.index, nextQuoteIndex - this.index);
+        this.value += this.csv.slice(this.index, nextQuoteIndex);
         this.index = nextQuoteIndex + 1;
         this.line.push(this.value);
         this.value = '';

--- a/app/scripts/util/data/otp.js
+++ b/app/scripts/util/data/otp.js
@@ -93,7 +93,7 @@ Otp.prototype.hmac = function (data, callback) {
 
 Otp.hmacToDigits = function (hmac, length) {
     let code = hmac.toString();
-    code = Otp.leftPad(code.substr(code.length - length), length);
+    code = Otp.leftPad(code.slice(-length), length);
     return code;
 };
 
@@ -121,7 +121,7 @@ Otp.fromBase32 = function (str) {
     }
     const hex = new Uint8Array(Math.floor(bin.length / 8));
     for (i = 0; i < hex.length; i++) {
-        const chunk = bin.substr(i * 8, 8);
+        const chunk = bin.slice(i * 8, i * 8 + 8);
         hex[i] = parseInt(chunk, 2);
     }
     return hex.buffer;

--- a/app/scripts/util/formatting/string-format.js
+++ b/app/scripts/util/formatting/string-format.js
@@ -5,7 +5,7 @@ const StringFormat = {
         if (!str) {
             return '';
         }
-        return str[0].toUpperCase() + str.substr(1);
+        return str[0].toUpperCase() + str.slice(1);
     },
 
     pad(num, digits) {

--- a/app/scripts/util/formatting/url-format.js
+++ b/app/scripts/util/formatting/url-format.js
@@ -7,7 +7,7 @@ const UrlFormat = {
     getDataFileName(url) {
         const ix = url.lastIndexOf('/');
         if (ix >= 0) {
-            url = url.substr(ix + 1);
+            url = url.slice(ix + 1);
         }
         url = url.replace(/\?.*/, '').replace(/\.kdbx/i, '');
         return url;

--- a/app/scripts/util/generators/password-generator.js
+++ b/app/scripts/util/generators/password-generator.js
@@ -100,7 +100,7 @@ const PasswordGenerator = {
             }
             result += ch;
         }
-        return result.substr(0, opts.length);
+        return result.slice(0, opts.length);
     },
 
     deriveOpts(password) {

--- a/app/scripts/util/generators/phonetic.js
+++ b/app/scripts/util/generators/phonetic.js
@@ -316,7 +316,7 @@ function generate(options) {
     while (wordObj.word.length < safeMaxLength) {
         addSyllable(wordObj);
     }
-    return postProcess(wordObj).substr(0, length);
+    return postProcess(wordObj).slice(0, length);
 }
 
 const phonetic = { generate };

--- a/app/scripts/views/auto-type/auto-type-hint-view.js
+++ b/app/scripts/views/auto-type/auto-type-hint-view.js
@@ -75,7 +75,7 @@ class AutoTypeHintView extends View {
 
     insertText(text) {
         const pos = this.input.selectionEnd || this.input.value.length;
-        this.input.value = this.input.value.substr(0, pos) + text + this.input.value.substr(pos);
+        this.input.value = this.input.value.slice(0, pos) + text + this.input.value.slice(pos);
         this.input.selectionStart = this.input.selectionEnd = pos + text.length;
         this.input.dispatchEvent(new Event('input', { bubbles: true }));
     }

--- a/app/scripts/views/details/details-view.js
+++ b/app/scripts/views/details/details-view.js
@@ -335,7 +335,7 @@ class DetailsView extends View {
                 break;
             default:
                 if (e.item.lastIndexOf('add:', 0) === 0) {
-                    const fieldName = e.item.substr(4);
+                    const fieldName = e.item.slice(4);
                     const fieldView = this.fieldViews.find((f) => f.model.name === fieldName);
                     fieldView.show();
                     fieldView.edit();
@@ -571,7 +571,7 @@ class DetailsView extends View {
     fieldChanged(e) {
         if (e.field) {
             if (e.field[0] === '$') {
-                let fieldName = e.field.substr(1);
+                let fieldName = e.field.slice(1);
                 if (fieldName === 'otp') {
                     if (this.otpFieldChanged(e.val)) {
                         this.entryUpdated();

--- a/app/scripts/views/fields/field-view-tags.js
+++ b/app/scripts/views/fields/field-view-tags.js
@@ -94,7 +94,7 @@ class FieldViewTags extends FieldViewText {
                 const last = tags[tags.length - 1];
                 const isLastPart = last && this.model.tags.indexOf(last) < 0;
                 if (isLastPart) {
-                    newVal = newVal.substr(0, newVal.lastIndexOf(last)) + selectedTag;
+                    newVal = newVal.substring(0, newVal.lastIndexOf(last)) + selectedTag;
                 } else {
                     newVal += ', ' + selectedTag;
                 }

--- a/app/scripts/views/select/select-entry-view.js
+++ b/app/scripts/views/select/select-entry-view.js
@@ -228,10 +228,7 @@ class SelectEntryView extends View {
 
     backSpacePressed() {
         if (this.model.filter.text) {
-            this.model.filter.text = this.model.filter.text.substr(
-                0,
-                this.model.filter.text.length - 1
-            );
+            this.model.filter.text = this.model.filter.text.slice(0, -1);
             this.render();
         }
     }

--- a/build/loaders/fontawesome-loader.js
+++ b/build/loaders/fontawesome-loader.js
@@ -18,7 +18,7 @@ for (const svgDir of svgDirs) {
         .filter((icon) => icon.endsWith('.svg'))
         .forEach((icon) => {
             const svgIconPath = path.join(svgDir, icon);
-            const iconName = icon.substr(0, icon.length - 4) + suffix;
+            const iconName = icon.slice(0, -4) + suffix;
             allIcons[iconName] = svgIconPath;
         });
 }

--- a/build/tasks/grunt-sign-desktop-files.js
+++ b/build/tasks/grunt-sign-desktop-files.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
                 if (stat && stat.isDirectory()) {
                     await walk(file);
                 } else {
-                    const relFile = file.substr(appPath.length + 1);
+                    const relFile = file.slice(appPath.length + 1);
                     const fileData = grunt.file.read(file, { encoding: null });
                     signatures[relFile] = await getSignature(fileData);
                     signedFiles.push(relFile);

--- a/desktop/scripts/ipc-handlers/browser-extension-connector.js
+++ b/desktop/scripts/ipc-handlers/browser-extension-connector.js
@@ -329,7 +329,7 @@ async function processFirstMessageFromSocket(socket, message) {
         appName = parentProcessInfo
             ? AppNames[parentProcessInfo.appName] ?? parentProcessInfo.appName
             : 'Unidentified browser';
-        appName = appName[0].toUpperCase() + appName.substr(1);
+        appName = appName[0].toUpperCase() + appName.slice(1);
     }
 
     state.active = true;

--- a/package/osx/installer.js
+++ b/package/osx/installer.js
@@ -135,7 +135,7 @@ function checkFilePath(path, ext) {
     if (!path) {
         throw 'File not specified: ' + ext;
     }
-    if (path.substr(-(ext.length + 1)) !== '.' + ext) {
+    if (path.slice(-(ext.length + 1)) !== '.' + ext) {
         throw 'Bad file extension: ' + ext + ' (' + path + ')';
     }
     var file = Application('System Events').files.byName(path);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.