### PR TITLE
fix #2027: show space characters on reveal

### DIFF
--- a/app/scripts/util/formatting/password-presenter.js
+++ b/app/scripts/util/formatting/password-presenter.js
@@ -8,6 +8,8 @@ class RandomNameGenerator {
 }
 
 function charCodeToHtml(char) {
+    // In case of SPACE character we change to non-breaking space, so it will be shown as &#nbsp;
+    if (char === 32) char = 160;
     return Math.random() < 0.2 ? String.fromCharCode(char) : `&#x${char.toString(16)};`;
 }
 


### PR DESCRIPTION
When obfuscating "revealed" password - we generate html like this:
`<div style="order: 3;"> </div>`

In this case SPACE is not shown. My idea is to replace SPACE with non-breaking space. It will generate such html:
`<div style="order: 3;">&nbsp;</div>`