### PR TITLE
Fix remove key file

### DIFF
--- a/app/scripts/models/file-model.js
+++ b/app/scripts/models/file-model.js
@@ -536,7 +536,7 @@ class FileModel extends Model {
     }
 
     removeKeyFile() {
-        this.db.credentials.keyFileHash = null;
+        this.db.credentials.setKeyFile(null);
         const changed = !!this.oldKeyFileHash;
         if (!changed && this.db.credentials.passwordHash === this.oldPasswordHash) {
             this.db.meta.keyChanged = this.oldKeyChangeDate;


### PR DESCRIPTION
This fixes the issue #1924

So as kdbxweb has protected property `keyFileHash` in credentials, it must not been set to null without setter.