### PR TITLE
fix: addresses not being able to unset a keyfile once added to a vault

### DIFF
--- a/app/scripts/models/file-model.js
+++ b/app/scripts/models/file-model.js
@@ -536,7 +536,7 @@ class FileModel extends Model {
     }
 
     removeKeyFile() {
-        this.db.credentials.keyFileHash = null;
+        this.db.credentials.setKeyFile(null);
         const changed = !!this.oldKeyFileHash;
         if (!changed && this.db.credentials.passwordHash === this.oldPasswordHash) {
             this.db.meta.keyChanged = this.oldKeyChangeDate;


### PR DESCRIPTION
### Summary
This PR addresses the issue with users not being able to unassign a keyfile once a vault has been created with one.

### References
- #2073
- #1924 
- #2038 
- #1941