### PR TITLE
fix: convert space character to non-breaking space on password reveal

### DIFF
--- a/app/scripts/util/formatting/password-presenter.js
+++ b/app/scripts/util/formatting/password-presenter.js
@@ -11,9 +11,9 @@ class RandomNameGenerator {
 function charCodeToHtml(char) {
     // convert certain special chars like space into to non-breaking space
     // ' ' to &#nbsp;
-    if ( char === 32 || char === 8193 || char === 8239 )
+    if ( char === 32 || char === 8193 || char === 8239 ) {
         char = 160;
-
+    }
     return Math.random( ) < 0.2 ? String.fromCharCode( char ) : `&#x${ char.toString( 16 ) };`;
 }
 

--- a/app/scripts/util/formatting/password-presenter.js
+++ b/app/scripts/util/formatting/password-presenter.js
@@ -7,8 +7,14 @@ class RandomNameGenerator {
     }
 }
 
+// activated when user presses 'reveal' on password
 function charCodeToHtml(char) {
-    return Math.random() < 0.2 ? String.fromCharCode(char) : `&#x${char.toString(16)};`;
+    // convert certain special chars like space into to non-breaking space
+    // ' ' to &#nbsp;
+    if ( char === 32 || char === 8193 || char === 8239 )
+        char = 160;
+
+    return Math.random( ) < 0.2 ? String.fromCharCode( char ) : `&#x${ char.toString( 16 ) };`;
 }
 
 const PasswordPresenter = {

--- a/app/scripts/util/formatting/password-presenter.js
+++ b/app/scripts/util/formatting/password-presenter.js
@@ -7,14 +7,13 @@ class RandomNameGenerator {
     }
 }
 
-// activated when user presses 'reveal' on password
 function charCodeToHtml(char) {
     // convert certain special chars like space into to non-breaking space
     // ' ' to &#nbsp;
-    if ( char === 32 || char === 8193 || char === 8239 ) {
+    if (char === 32 || char === 8193 || char === 8239) {
         char = 160;
     }
-    return Math.random( ) < 0.2 ? String.fromCharCode( char ) : `&#x${ char.toString( 16 ) };`;
+    return Math.random() < 0.2 ? String.fromCharCode(char) : `&#x${char.toString(16)};`;
 }
 
 const PasswordPresenter = {


### PR DESCRIPTION
### Summary
This fix applies to the **Reveal Password** button.
Converts spaces and a few other characters empty characters into non-breaking spaces so that they'll render properly in the password field.