### PR TITLE
Update to new UUID for firefox extension

### DIFF
--- a/desktop/scripts/const/extension-ids.js
+++ b/desktop/scripts/const/extension-ids.js
@@ -2,7 +2,7 @@ module.exports.ExtensionIds = {
     Origins: {
         KeeWebConnectChrome: 'chrome-extension://pikpfmjfkekaeinceagbebpfkmkdlcjk/',
         KeeWebConnectEdge: 'chrome-extension://nmggpehkjmeaeocmaijenpejbepckinm/',
-        KeeWebConnectFirefox: 'keeweb-connect@keeweb.info',
+        KeeWebConnectFirefox: 'keeweb-connect-addon@keeweb.info',
         KeeWebConnectSafari: 'safari-keeweb-connect',
         KeePassXcBrowserFirefox: 'keepassxc-browser@keepassxc.org',
         KeePassXcBrowserChrome: 'chrome-extension://oboonakemofpalcgghocfoadofidjkkk/',


### PR DESCRIPTION
We are changing the UUID since we don't have access to the closed account or now revoked add-on so we need to use a new UUID for native messaging.

See https://github.com/keeweb/keeweb-connect/pull/55