### PR TITLE
Simplify font family and set `lang` attr to <html>

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-    <head lang="en">
+    <head>
         <meta charset="UTF-8" />
         <title>KeeWeb</title>
         <meta

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -133,6 +133,7 @@ ready(() => {
                 }
             })
             .then(() => {
+                $('html').attr('lang', SettingsManager.activeLocale);
                 StartProfiler.milestone('loading remote config');
             });
     }

--- a/app/scripts/views/app-view.js
+++ b/app/scripts/views/app-view.js
@@ -832,6 +832,7 @@ class AppView extends View {
             this.showSettings();
         }
         this.$el.find('.app__beta:first').text(Locale.appBeta);
+        $('html').attr('lang', SettingsManager.activeLocale);
     }
 
     extLinkClick(e) {

--- a/app/styles/base/_variables.scss
+++ b/app/styles/base/_variables.scss
@@ -1,7 +1,5 @@
 // Typography
-$base-font-family: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Helvetica',
-    'Roboto', 'Arial', 'Microsoft YaHei', '微软雅黑', 'PingFang SC', 'Hiragino Sans GB', 'STXihei',
-    '华文细黑', sans-serif;
+$base-font-family: Arial, sans-serif;
 $heading-font-family: $base-font-family;
 $monospace-font-family: 'SFMono-Regular', Monaco, Consolas, 'Lucida Console', monospace;
 

--- a/app/styles/base/_variables.scss
+++ b/app/styles/base/_variables.scss
@@ -1,5 +1,6 @@
 // Typography
-$base-font-family: Arial, sans-serif;
+$base-font-family: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Helvetica',
+    'Roboto', 'Arial', sans-serif;
 $heading-font-family: $base-font-family;
 $monospace-font-family: 'SFMono-Regular', Monaco, Consolas, 'Lucida Console', monospace;
 


### PR DESCRIPTION
In current version, fonts of Simplified Chinese are contained to `$base-font-family`, therefore Japanese and Traditional Chinese is displayed by using Simplified Chinese font. This is not good behavior for the aspect of i18n.

I propose to remove Simplified Chinese from the font setting, and instead of it, to set `lang` attribute to `html` element. By `lang` attribute, browser can determine which kanji font should be used.

I will show the examples as follows: 

[English]
![English](https://github.com/keeweb/keeweb/assets/7834440/b684ac12-8df3-4cd4-95ca-01610cb4dee6)

[Japanese]
![Japanese](https://github.com/keeweb/keeweb/assets/7834440/1f2d3219-8447-47a2-82da-c256b5e4f394)

[Simplified Chinese]
![Simplified Chinese](https://github.com/keeweb/keeweb/assets/7834440/a2d833fb-ab32-4257-8a7b-01a104569f49)

[Traditional Chinese]
![Traditional Chinese](https://github.com/keeweb/keeweb/assets/7834440/74a85822-3f3b-46ff-add6-a6b49adfdcb8)

Note: `$base-font-family: Arial, sans-serif;` setting is based on the settings of Google web page (https://www.google.com).