### PR TITLE
Hotfix: Downgrade gdrive scope to drive.file

### DIFF
--- a/app/scripts/storage/impl/storage-gdrive.js
+++ b/app/scripts/storage/impl/storage-gdrive.js
@@ -299,7 +299,7 @@ class StorageGDrive extends StorageBase {
             }
         }
         return {
-            scope: 'https://www.googleapis.com/auth/drive',
+            scope: 'https://www.googleapis.com/auth/drive.file',
             url: 'https://accounts.google.com/o/oauth2/v2/auth',
             tokenUrl: 'https://oauth2.googleapis.com/token',
             clientId,


### PR DESCRIPTION
We need to downgrade the google drive scope to drive.file, which allows keeweb to continue working without requiring any sort of extensive auditing verification from google.

I've tested this locally and it works fine, but we'll need to update the scope in the google drive api project as well to get this working

**Note**:
I just saw the note saying to use develop for normal features and master for hotfixes. This one is on master, but I think thats appropriate since this is an ugly little anti-feature that prevents usage of google drive. 

Hope this is ok, thanks!