### PR TITLE
Implement Google Picker for Drive file selection.

### DIFF
--- a/app/scripts/const/cloud-storage-apps.js
+++ b/app/scripts/const/cloud-storage-apps.js
@@ -11,8 +11,8 @@ const DropboxApps = {
 
 const GDriveApps = {
     Local: {
-        id: '783608538594-36tkdh8iscrq8t8dq87gghubnhivhjp5.apps.googleusercontent.com',
-        secret: 'yAtyfc9TIQ9GyQgQmo3i0HAP'
+        id: '590412965107-i6g9vqm11ubkfiftimosti1ogddqit0e.apps.googleusercontent.com',
+        secret: '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'
     },
     Production: {
         id: '847548101761-koqkji474gp3i2gn3k5omipbfju7pbt1.apps.googleusercontent.com',

--- a/app/scripts/storage/impl/storage-dropbox.js
+++ b/app/scripts/storage/impl/storage-dropbox.js
@@ -245,7 +245,7 @@ class StorageDropbox extends StorageBase {
     }
 
     _apiCall(args) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return args.error(err);
             }

--- a/app/scripts/storage/impl/storage-gdrive.js
+++ b/app/scripts/storage/impl/storage-gdrive.js
@@ -233,6 +233,7 @@ class StorageGDrive extends StorageBase {
                         const f = response;
                         const fileList = [
                             {
+                                auto: true,
                                 name: f.name,
                                 path: f.id,
                                 rev: f.headRevisionId,

--- a/app/scripts/storage/impl/storage-gdrive.js
+++ b/app/scripts/storage/impl/storage-gdrive.js
@@ -1,5 +1,4 @@
 import { StorageBase } from 'storage/storage-base';
-import { Locale } from 'util/locale';
 import { Features } from 'util/features';
 import { UrlFormat } from 'util/formatting/url-format';
 import { GDriveApps } from 'const/cloud-storage-apps';
@@ -50,7 +49,7 @@ class StorageGDrive extends StorageBase {
         if (path.lastIndexOf(NewFileIdPrefix, 0) === 0) {
             return callback && callback({ notFound: true });
         }
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -78,7 +77,7 @@ class StorageGDrive extends StorageBase {
     }
 
     save(path, opts, data, callback, rev) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -164,7 +163,16 @@ class StorageGDrive extends StorageBase {
     }
 
     list(dir, callback) {
-        this._oauthAuthorize((err) => {
+        const opts = {};
+        if (dir === undefined) {
+            opts.forceAuth = true;
+            opts.urlParams = {
+                'prompt': 'consent',
+                'trigger_onepick': 'true',
+                'mimetypes': 'application/x-keepass,x-application/kdbx,application/octet-stream'
+            };
+        }
+        this._oauthAuthorize(opts, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -202,24 +210,15 @@ class StorageGDrive extends StorageBase {
                     }
                 });
             } else {
-                let query = 'trashed=false and ';
-                if (dir === 'shared') {
-                    query += 'sharedWithMe=true';
-                } else if (dir) {
-                    query += `"${dir}" in parents`;
-                } else {
-                    query += '"root" in parents';
-                }
-
                 const urlParams = {
-                    fields: 'files(id,name,mimeType,headRevisionId)',
-                    q: query,
-                    pageSize: 1000,
-                    includeItemsFromAllDrives: true,
+                    fields: 'id,name,mimeType,headRevisionId',
                     supportsAllDrives: true
                 };
 
-                const url = UrlFormat.makeUrl(`${this._baseUrl}/files`, urlParams);
+                const url = UrlFormat.makeUrl(
+                    `${this._baseUrl}/files/${this._pickedFileId}`,
+                    urlParams
+                );
 
                 this._xhr({
                     url,
@@ -231,26 +230,15 @@ class StorageGDrive extends StorageBase {
                         }
                         this.logger.debug('Listed', this.logger.ts(ts));
 
-                        const fileList = response.files.map((f) => ({
-                            name: f.name,
-                            path: f.id,
-                            rev: f.headRevisionId,
-                            dir: f.mimeType === 'application/vnd.google-apps.folder'
-                        }));
-                        if (!dir) {
-                            fileList.unshift({
-                                name: Locale.gdriveSharedWithMe,
-                                path: 'shared',
-                                rev: undefined,
-                                dir: true
-                            });
-                            fileList.unshift({
-                                name: Locale.gdriveSharedDrives,
-                                path: 'drives',
-                                rev: undefined,
-                                dir: true
-                            });
-                        }
+                        const f = response;
+                        const fileList = [
+                            {
+                                name: f.name,
+                                path: f.id,
+                                rev: f.headRevisionId,
+                                dir: f.mimeType === 'application/vnd.google-apps.folder'
+                            }
+                        ];
                         return callback?.(null, fileList);
                     },
                     error: (err) => {
@@ -309,6 +297,16 @@ class StorageGDrive extends StorageBase {
             pkce: true,
             urlParams: this.appSettings.shortLivedStorageToken ? {} : { 'access_type': 'offline' }
         };
+    }
+
+    _oauthProcessCode(result) {
+        const fileId = result.picked_file_ids;
+        if (fileId) {
+            this.logger.debug('Picker success', fileId);
+            this._pickedFileId = fileId;
+        } else {
+            this.logger.error('Picker failure');
+        }
     }
 }
 

--- a/app/scripts/storage/impl/storage-onedrive.js
+++ b/app/scripts/storage/impl/storage-onedrive.js
@@ -17,7 +17,7 @@ class StorageOneDrive extends StorageBase {
     }
 
     load(path, opts, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -64,7 +64,7 @@ class StorageOneDrive extends StorageBase {
     }
 
     stat(path, opts, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -96,7 +96,7 @@ class StorageOneDrive extends StorageBase {
     }
 
     save(path, opts, data, callback, rev) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -132,7 +132,7 @@ class StorageOneDrive extends StorageBase {
     }
 
     list(dir, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -187,7 +187,7 @@ class StorageOneDrive extends StorageBase {
     }
 
     mkdir(path, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }

--- a/app/scripts/storage/impl/storage-teams.js
+++ b/app/scripts/storage/impl/storage-teams.js
@@ -62,7 +62,7 @@ class StorageTeams extends StorageBase {
     }
 
     load(path, opts, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -118,7 +118,7 @@ class StorageTeams extends StorageBase {
     }
 
     stat(path, opts, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -159,7 +159,7 @@ class StorageTeams extends StorageBase {
     }
 
     save(path, opts, data, callback, rev) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -204,7 +204,7 @@ class StorageTeams extends StorageBase {
     }
 
     list(dir, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }
@@ -289,7 +289,7 @@ class StorageTeams extends StorageBase {
     }
 
     mkdir(path, callback) {
-        this._oauthAuthorize((err) => {
+        this._oauthAuthorize({}, (err) => {
             if (err) {
                 return callback && callback(err);
             }

--- a/app/scripts/storage/storage-base.js
+++ b/app/scripts/storage/storage-base.js
@@ -209,21 +209,21 @@ class StorageBase {
         return new URL(`oauth-result/${this.name}.html`, redirectUrl).href;
     }
 
-    _oauthAuthorize(callback) {
-        if (this._tokenIsValid(this._oauthToken)) {
-            return callback();
-        }
-        const opts = this._getOAuthConfig();
-        const oldToken = this.runtimeData[this.name + 'OAuthToken'];
-        if (this._tokenIsValid(oldToken)) {
-            this._oauthToken = oldToken;
-            return callback();
-        }
+    _oauthAuthorize(opts, callback) {
+        if (opts.forceAuth !== true) {
+            if (this._tokenIsValid(this._oauthToken)) {
+                return callback();
+            }
+            const oldToken = this.runtimeData[this.name + 'OAuthToken'];
+            if (this._tokenIsValid(oldToken)) {
+                this._oauthToken = oldToken;
+                return callback();
+            }
 
-        if (oldToken && oldToken.refreshToken) {
-            return this._oauthExchangeRefreshToken(callback);
+            if (oldToken && oldToken.refreshToken) {
+                return this._oauthExchangeRefreshToken(callback);
+            }
         }
-
         const session = createOAuthSession();
 
         let listener;
@@ -234,20 +234,22 @@ class StorageBase {
             session.redirectUri = this._getOauthRedirectUrl();
         }
 
-        const pkceParams = opts.pkce
+        const config = this._getOAuthConfig();
+        const pkceParams = config.pkce
             ? {
                   'code_challenge': session.codeChallenge,
                   'code_challenge_method': 'S256'
               }
             : undefined;
 
-        const url = UrlFormat.makeUrl(opts.url, {
-            'client_id': opts.clientId,
-            'scope': opts.scope,
+        const url = UrlFormat.makeUrl(config.url, {
+            'client_id': config.clientId,
+            'scope': config.scope,
             'state': session.state,
             'redirect_uri': session.redirectUri,
             'response_type': 'code',
             ...pkceParams,
+            ...config.urlParams,
             ...opts.urlParams
         });
 
@@ -261,7 +263,7 @@ class StorageBase {
             return;
         }
 
-        const popupWindow = this._openPopup(url, 'OAuth', opts.width, opts.height);
+        const popupWindow = this._openPopup(url, 'OAuth', config.width, config.height);
         if (!popupWindow) {
             return callback('OAuth: cannot open popup');
         }
@@ -355,7 +357,7 @@ class StorageBase {
         if (this._oauthToken.refreshToken) {
             this._oauthExchangeRefreshToken(callback);
         } else {
-            this._oauthAuthorize(callback);
+            this._oauthAuthorize({}, callback);
         }
     }
 
@@ -404,6 +406,8 @@ class StorageBase {
         if (Features.isDesktop) {
             Launcher.showMainWindow();
         }
+
+        this._oauthProcessCode?.(result);
         const config = this._getOAuthConfig();
         const pkceParams = config.pkce ? { 'code_verifier': session.codeVerifier } : undefined;
 
@@ -465,7 +469,7 @@ class StorageBase {
                     delete this.runtimeData[this.name + 'OAuthToken'];
                     this._oauthToken = null;
                     this.logger.error('Error exchanging refresh token, trying to authorize again');
-                    this._oauthAuthorize(callback);
+                    this._oauthAuthorize({}, callback);
                 } else {
                     this.logger.error('Error exchanging refresh token', err);
                     callback?.('Error exchanging refresh token');

--- a/app/scripts/views/open-view.js
+++ b/app/scripts/views/open-view.js
@@ -824,6 +824,12 @@ class OpenView extends View {
                 return;
             }
 
+            const autoFile = files.find((f) => f.auto);
+            if (autoFile) {
+                this.openStorageFile(storage, autoFile);
+                return;
+            }
+
             const fileNameComparator = Comparators.stringComparator('path', true);
             files.sort((x, y) => {
                 if (x.dir !== y.dir) {


### PR DESCRIPTION
This pull request implements the Google Picker for allowing access to Google Drive files under the `drive.file` API scope.  Since the API scope is unrestricted the application does not require verification.

## User experience

When the user selects "Google Drive" to open a file, they will be directed to the OAuth consent flow.  After approving access the flow will take them to Google Picker, where they can select a KDBX file.

<img width="638" height="506" src="https://github.com/user-attachments/assets/97b5586f-a9e3-4591-bae1-3b47aa66cff3" />

(At this point, the Drive service has granted the client permission to access the file.)

~~After selecting a file, the OAuth window will close and KeeWeb will list only the selected file.  The user must click the file to open it.~~

After selecting a file, the OAuth window will close and KeeWeb will automatically open the selected file.

After this, the UX continues normally.