### PR TITLE
feat(mac): auto-prompt Touch ID on open and harden hardware crypto checks

### DIFF
--- a/app/scripts/views/open-view.js
+++ b/app/scripts/views/open-view.js
@@ -63,6 +63,7 @@ class OpenView extends View {
     busy = false;
     currentSelectedIndex = -1;
     encryptedPassword = null;
+    autoUnlockAttemptedRef = null;
 
     constructor(model) {
         super(model);
@@ -155,6 +156,7 @@ class OpenView extends View {
     windowFocused() {
         this.inputEl.focus();
         this.checkIfEncryptedPasswordDateIsValid();
+        this.displayOpenDeviceOwnerAuth();
     }
 
     focusInput(focusOnMobile) {
@@ -361,6 +363,46 @@ class OpenView extends View {
         this.el
             .querySelector('.open__pass-enter-btn')
             .classList.toggle('open__pass-enter-btn--touch-id', canUseEncryptedPassword);
+        if (canUseEncryptedPassword) {
+            this.maybeAutoTriggerDeviceOwnerAuth();
+        }
+    }
+
+    getCurrentAutoUnlockRef() {
+        return (
+            this.params.id || [this.params.storage, this.params.path, this.params.name].join('|')
+        );
+    }
+
+    maybeAutoTriggerDeviceOwnerAuth() {
+        if (
+            this.busy ||
+            !this.params.name ||
+            !this.encryptedPassword ||
+            this.passwordInput.length ||
+            !FocusDetector.hasFocus()
+        ) {
+            return;
+        }
+
+        const unlockRef = this.getCurrentAutoUnlockRef();
+        if (!unlockRef || this.autoUnlockAttemptedRef === unlockRef) {
+            return;
+        }
+
+        this.autoUnlockAttemptedRef = unlockRef;
+        this.afterPaint(() => {
+            if (
+                this.getCurrentAutoUnlockRef() !== unlockRef ||
+                this.busy ||
+                !this.encryptedPassword ||
+                this.passwordInput.length ||
+                !FocusDetector.hasFocus()
+            ) {
+                return;
+            }
+            this.openDb();
+        });
     }
 
     setFile(file, keyFile, fileReadyCallback) {

--- a/desktop/scripts/ipc-handlers/hardware-crypto.js
+++ b/desktop/scripts/ipc-handlers/hardware-crypto.js
@@ -1,9 +1,11 @@
 const { ipcMain } = require('electron');
+const { spawnSync } = require('child_process');
 const { readXoredValue, makeXoredValue } = require('../util/byte-utils');
 const { reqNative } = require('../util/req-native');
 const { isDev } = require('../util/app-info');
 
 ipcMain.handle('hardwareCryptoDeleteKey', hardwareCryptoDeleteKey);
+ipcMain.handle('hardwareCryptoGetStatus', hardwareCryptoGetStatus);
 ipcMain.handle('hardwareEncrypt', hardwareEncrypt);
 ipcMain.handle('hardwareDecrypt', hardwareDecrypt);
 
@@ -11,11 +13,28 @@ const keyTag = 'net.antelle.keeweb.encryption-key';
 
 let testCipherParams;
 let keyChecked = false;
+let hardwareCryptoStatus;
+
+const requiredTouchIdEntitlements = [
+    '<key>com.apple.application-identifier</key>',
+    '<key>com.apple.developer.team-identifier</key>',
+    '<key>keychain-access-groups</key>'
+];
 
 async function hardwareCryptoDeleteKey() {
+    const status = getHardwareCryptoStatus();
+    if (!status.supported) {
+        keyChecked = false;
+        return false;
+    }
     const secureEnclave = reqNative('secure-enclave');
     await secureEnclave.deleteKeyPair({ keyTag });
     keyChecked = false;
+    return true;
+}
+
+async function hardwareCryptoGetStatus() {
+    return getHardwareCryptoStatus();
 }
 
 async function hardwareEncrypt(e, value) {
@@ -30,6 +49,8 @@ async function hardwareCrypto(value, encrypt, touchIdPrompt) {
     if (process.platform !== 'darwin') {
         throw new Error('Not supported');
     }
+
+    ensureHardwareCryptoSupported();
 
     // This is a native module, but why is it here and not in native-module-host?
     // It's because native-module-host is started as a fork,
@@ -89,4 +110,85 @@ async function hardwareCrypto(value, encrypt, touchIdPrompt) {
             }
         }
     }
+}
+
+function getHardwareCryptoStatus() {
+    if (hardwareCryptoStatus) {
+        return hardwareCryptoStatus;
+    }
+
+    if (isDev && process.env.KEEWEB_EMULATE_HARDWARE_ENCRYPTION) {
+        hardwareCryptoStatus = { supported: true };
+        return hardwareCryptoStatus;
+    }
+
+    const signatureInfo = getCodeSignInfo();
+    if (!signatureInfo.signed) {
+        hardwareCryptoStatus = {
+            supported: false,
+            code: 'signature-missing',
+            message:
+                'Touch ID is unavailable in this build because the app is not signed with a developer identity.'
+        };
+        return hardwareCryptoStatus;
+    }
+
+    if (!signatureInfo.hasRequiredEntitlements) {
+        hardwareCryptoStatus = {
+            supported: false,
+            code: 'entitlements-missing',
+            message:
+                'Touch ID is unavailable in this build because required macOS entitlements are missing.'
+        };
+        return hardwareCryptoStatus;
+    }
+
+    hardwareCryptoStatus = { supported: true };
+    return hardwareCryptoStatus;
+}
+
+function ensureHardwareCryptoSupported() {
+    const status = getHardwareCryptoStatus();
+    if (status.supported) {
+        return;
+    }
+
+    const err = new Error(status.message || 'Touch ID is not available');
+    err.notSupported = true;
+    err.reasonCode = status.code || 'not-supported';
+    throw err;
+}
+
+function getCodeSignInfo() {
+    const signature = spawnSync('/usr/bin/codesign', ['-dv', process.execPath], {
+        encoding: 'utf8'
+    });
+    const signatureOut = `${signature.stdout || ''}\n${signature.stderr || ''}`;
+    const teamIdentifierMatch = signatureOut.match(/TeamIdentifier=(.*)$/m);
+    const teamIdentifier = teamIdentifierMatch?.[1]?.trim();
+    const signed = signature.status === 0 && !!teamIdentifier && teamIdentifier !== 'not set';
+
+    if (!signed) {
+        return {
+            signed: false,
+            hasRequiredEntitlements: false
+        };
+    }
+
+    const entitlements = spawnSync(
+        '/usr/bin/codesign',
+        ['-d', '--entitlements', ':-', process.execPath],
+        {
+            encoding: 'utf8'
+        }
+    );
+    const entitlementsOut = `${entitlements.stdout || ''}\n${entitlements.stderr || ''}`;
+    const hasRequiredEntitlements =
+        entitlements.status === 0 &&
+        requiredTouchIdEntitlements.every((entitlement) => entitlementsOut.includes(entitlement));
+
+    return {
+        signed: true,
+        hasRequiredEntitlements
+    };
 }


### PR DESCRIPTION
## Summary
- auto-trigger Touch ID prompt immediately after opening a protected file (no extra click required)
- add robust capability checks before calling hardware crypto APIs
- avoid crashes when Secure Enclave / biometrics are unavailable by gracefully handling unsupported/error states

## Scope
- `app/scripts/views/open-view.js`
- `desktop/scripts/ipc-handlers/hardware-crypto.js`

## Explicitly out of scope
- no signing/provisioning/certificate changes
- no entitlements changes
- no app-id/team-id specific configuration

## Notes
- this is based on behavior observed on macOS with Touch ID unlock flows
- local lint/test run was not executed in this PR branch because dependencies are not installed in this environment
