### PR TITLE
feat(ui): redesign settings pages for clearer structure and consistency

### DIFF
--- a/app/styles/areas/_settings.scss
+++ b/app/styles/areas/_settings.scss
@@ -12,6 +12,31 @@
 
     &__content {
         margin: $medium-padding;
+        max-width: 980px;
+    }
+
+    &__content--cards,
+    &__content--file {
+        width: 100%;
+        max-width: 980px;
+        margin: $medium-padding auto;
+        padding-left: $small-spacing;
+        padding-right: $small-spacing;
+        padding-bottom: $medium-padding-v;
+        box-sizing: border-box;
+
+        input.settings__input[type='text'],
+        input.settings__input[type='password'],
+        select.settings__select {
+            min-height: 2.2em;
+            border-radius: calc(var(--input-border-radius) + 3px);
+            padding-left: $small-spacing;
+            padding-right: $small-spacing;
+        }
+
+        select.settings__select {
+            background-position: calc(100% - 10px) center;
+        }
     }
 
     > .scroller {
@@ -21,6 +46,130 @@
     h2,
     h3 {
         margin-top: 20px;
+    }
+
+    &__title {
+        margin: 0;
+        display: flex;
+        align-items: center;
+        gap: $small-spacing;
+    }
+
+    &__meta {
+        color: var(--muted-color);
+        margin: $small-spacing 0;
+    }
+
+    &__error {
+        color: var(--error-color);
+        margin: $small-spacing 0 0;
+    }
+
+    &__section {
+        margin-top: $base-spacing;
+        padding: $medium-padding;
+        border: light-border();
+        border-radius: calc(var(--input-border-radius) + 6px);
+        background: var(--secondary-background-color);
+        box-shadow: form-box-shadow();
+
+        > h2 {
+            margin: 0 0 $small-spacing;
+            line-height: 1.25em;
+        }
+    }
+
+    &__section--header {
+        margin-top: 0;
+    }
+
+    &__section-subtitle {
+        margin: 0 0 $small-spacing;
+        font-size: 1rem;
+    }
+
+    &__field {
+        display: grid;
+        grid-template-columns: minmax(11em, 15em) minmax(18em, 40em);
+        column-gap: $base-spacing;
+        align-items: center;
+        justify-content: start;
+        margin-bottom: $small-spacing;
+
+        > label {
+            margin: 0;
+        }
+
+        > label.input-base {
+            width: auto;
+        }
+
+        > .settings__input,
+        > .settings__select,
+        > .input-base {
+            width: 100%;
+            max-width: 40em;
+            margin: 0;
+        }
+    }
+
+    &__field-controls {
+        width: 100%;
+        max-width: 40em;
+
+        > .settings__input,
+        > .settings__select,
+        > .input-base {
+            width: 100%;
+            max-width: 40em;
+            margin: 0;
+        }
+
+        > a {
+            display: inline-block;
+            margin-top: $tiny-spacing;
+        }
+
+        #settings__file-confirm-master-pass-group {
+            margin-top: $small-spacing;
+        }
+
+        #settings__file-confirm-master-pass-group > label.input-base {
+            width: auto;
+        }
+    }
+
+    &__field--stack {
+        display: block;
+
+        > label {
+            display: block;
+            margin-bottom: $small-spacing / 2;
+        }
+
+        > .settings__input,
+        > .settings__select,
+        > .input-base {
+            width: 100%;
+            max-width: 40em;
+        }
+    }
+
+    &__check-row {
+        margin-bottom: $small-spacing;
+    }
+
+    &__check-row--with-help {
+        display: flex;
+        align-items: center;
+        gap: $tiny-spacing;
+    }
+
+    &__file-buttons {
+        margin-top: $small-spacing;
+        display: flex;
+        flex-wrap: wrap;
+        gap: $small-spacing;
     }
 
     .shortcut {
@@ -101,10 +250,27 @@
         height: 2em;
     }
 
+    &__shortcut-row {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        align-items: center;
+        gap: $small-spacing;
+    }
+
     &__row {
         display: flex;
         justify-content: space-between;
         @extend .input-size-base;
+    }
+
+    &__row--kdf {
+        width: 100%;
+        gap: $base-spacing;
+
+        .settings__col-small {
+            width: auto;
+            flex: 1 1 0;
+        }
     }
 
     &__col-small {
@@ -152,10 +318,16 @@
             display: inline-block;
             margin-right: $base-padding-h;
             text-align: center;
+            border: light-border();
+            border-radius: var(--input-border-radius);
+            padding: $small-spacing;
+            min-width: 8.5em;
+            margin-bottom: $small-spacing;
+            background: var(--background-color);
 
             > i {
                 display: block;
-                font-size: 3em;
+                font-size: 2.5em;
                 padding: $base-padding-px;
                 margin: auto;
             }
@@ -163,8 +335,15 @@
             &:hover {
                 transition: color $base-duration $base-timing;
                 color: var(--medium-color);
+                box-shadow: form-box-shadow-hover();
             }
         }
+    }
+
+    &__file-save-choose {
+        margin-top: $base-spacing;
+        padding-top: $base-spacing;
+        border-top: light-border();
     }
 
     &__general-update-buttons {
@@ -236,6 +415,22 @@
         }
     }
     &__plugins {
+        &-list {
+            display: flex;
+            flex-direction: column;
+            gap: $base-spacing;
+        }
+        &-plugin {
+            border: light-border();
+            border-radius: var(--input-border-radius);
+            background: var(--background-color);
+            padding: $medium-padding;
+        }
+        &-plugin-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: $small-spacing;
+        }
         &-install-error {
             margin-top: $base-padding-v;
         }
@@ -308,6 +503,17 @@
         }
     }
     &__browser {
+        &-session-card {
+            margin-top: $base-spacing;
+            padding-top: $base-spacing;
+            border-top: light-border();
+
+            &:first-of-type {
+                margin-top: 0;
+                padding-top: 0;
+                border-top: 0;
+            }
+        }
         &-table {
             th,
             td {
@@ -370,5 +576,42 @@
         position: relative;
         top: 0.1em;
         margin-right: 0.2em;
+    }
+
+    @include mobile {
+        &__content--cards,
+        &__content--file {
+            margin: $small-spacing auto;
+            padding-left: $tiny-spacing;
+            padding-right: $tiny-spacing;
+        }
+
+        &__section {
+            padding: $base-padding;
+        }
+
+        &__field {
+            grid-template-columns: minmax(9em, 13em) minmax(0, 1fr);
+            column-gap: $small-spacing;
+            align-items: start;
+
+            > label {
+                margin-top: 0.25em;
+            }
+
+            > .settings__input,
+            > .settings__select,
+            > .input-base {
+                width: 100%;
+            }
+        }
+
+        &__row--kdf {
+            display: block;
+
+            .settings__col-small {
+                margin-bottom: $small-spacing;
+            }
+        }
     }
 }

--- a/app/templates/settings/settings-about.hbs
+++ b/app/templates/settings/settings-about.hbs
@@ -1,83 +1,89 @@
-<div class="settings__content">
-    <h1><i class="fa fa-info settings__head-icon"></i> {{res 'setAboutTitle'}} KeeWeb v{{version}}</h1>
-    <p>{{#res 'setAboutFirst'}}<a href="https://antelle.net" target="_blank">Antelle</a>{{/res~}}&nbsp;
-        {{~#res 'setAboutSecond'}}<a href="{{licenseLink}}" target="_blank">MIT</a>{{/res}}
-        {{#res 'setAboutSource'}}<a href="{{repoLink}}" target="_blank">GitHub <i class="fa fa-github-alt bottom"></i></a>{{/res}}</p>
-    <a href="{{donationLink}}" target="_blank" class="settings__donate-btn">
-        <span class="settings__donate-btn-top">Become a</span><span class="settings__donate-btn-bottom">Backer</span>
-    </a>
-    <p>{{res 'setAboutBuilt'}}:</p>
-    <h3>Libraries</h3>
-    <ul>
-        {{#if isDesktop}}<li><a href="https://electron.atom.io/" target="_blank">electron</a><span class="muted-color">, cross-platform desktop apps framework, &copy; 2013-2020 GitHub Inc.</span></li>{{/if}}
-        <li><a href="https://handlebarsjs.com/" target="_blank">handlebars</a><span class="muted-color">, minimal templating on steroids, &copy; 2011-2019 by Yehuda Katz</span></li>
-        <li><a href="https://github.com/patrick-steele-idem/morphdom" target="_blank">morphdom</a><span class="muted-color">, fast and lightweight DOM diffing/patching, &copy; Patrick Steele-Idem &lt;pnidem@gmail.com&gt; (psteeleidem.com)</span></li>
-        <li><a href="https://lodash.com/" target="_blank">lodash</a><span class="muted-color">, a modern JavaScript utility library delivering modularity, performance & extras, &copy; OpenJS Foundation and other contributors &lt;https://openjsf.org/&gt;</span></li>
-        <li><a href="https://jquery.com/" target="_blank">jQuery</a><span class="muted-color">, fast, small, and feature-rich JavaScript library, &copy; OpenJS Foundation and other contributors, https://openjsf.org/</span></li>
+<div class="settings__content settings__content--cards">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-info settings__head-icon"></i> {{res 'setAboutTitle'}} KeeWeb v{{version}}</h1>
+        <p class="settings__meta">{{#res 'setAboutFirst'}}<a href="https://antelle.net" target="_blank">Antelle</a>{{/res~}}&nbsp;
+            {{~#res 'setAboutSecond'}}<a href="{{licenseLink}}" target="_blank">MIT</a>{{/res}}
+            {{#res 'setAboutSource'}}<a href="{{repoLink}}" target="_blank">GitHub <i class="fa fa-github-alt bottom"></i></a>{{/res}}</p>
+        <a href="{{donationLink}}" target="_blank" class="settings__donate-btn">
+            <span class="settings__donate-btn-top">Become a</span><span class="settings__donate-btn-bottom">Backer</span>
+        </a>
+    </section>
 
-    </ul>
+    <section class="settings__section">
+        <h2>{{res 'setAboutBuilt'}}</h2>
+        <h3>Libraries</h3>
+        <ul>
+            {{#if isDesktop}}<li><a href="https://electron.atom.io/" target="_blank">electron</a><span class="muted-color">, cross-platform desktop apps framework, &copy; 2013-2020 GitHub Inc.</span></li>{{/if}}
+            <li><a href="https://handlebarsjs.com/" target="_blank">handlebars</a><span class="muted-color">, minimal templating on steroids, &copy; 2011-2019 by Yehuda Katz</span></li>
+            <li><a href="https://github.com/patrick-steele-idem/morphdom" target="_blank">morphdom</a><span class="muted-color">, fast and lightweight DOM diffing/patching, &copy; Patrick Steele-Idem &lt;pnidem@gmail.com&gt; (psteeleidem.com)</span></li>
+            <li><a href="https://lodash.com/" target="_blank">lodash</a><span class="muted-color">, a modern JavaScript utility library delivering modularity, performance & extras, &copy; OpenJS Foundation and other contributors &lt;https://openjsf.org/&gt;</span></li>
+            <li><a href="https://jquery.com/" target="_blank">jQuery</a><span class="muted-color">, fast, small, and feature-rich JavaScript library, &copy; OpenJS Foundation and other contributors, https://openjsf.org/</span></li>
+        </ul>
 
-    <h3>Core components</h3>
-    <ul>
-        <li><a href="https://github.com/keeweb/kdbxweb" target="_blank">kdbxweb</a><span class="muted-color">, web kdbx library, &copy; 2016 Antelle</span></li>
-        <li><a href="https://nodeca.github.io/pako/" target="_blank">pako</a><span class="muted-color">, high speed zlib port to javascript, &copy; 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn</span></li>
-        <li><a href="https://github.com/inexorabletash/text-encoding" target="_blank">text-encoding</a><span class="muted-color">, polyfill for the Encoding Living Standard's API, public domain</span></li>
-        <li><a href="https://github.com/jindw/xmldom" target="_blank">xmldom</a><span class="muted-color">, a pure JS W3C Standard based DOMParser and XMLSerializer</span></li>
-    </ul>
+        <h3>Core components</h3>
+        <ul>
+            <li><a href="https://github.com/keeweb/kdbxweb" target="_blank">kdbxweb</a><span class="muted-color">, web kdbx library, &copy; 2016 Antelle</span></li>
+            <li><a href="https://nodeca.github.io/pako/" target="_blank">pako</a><span class="muted-color">, high speed zlib port to javascript, &copy; 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn</span></li>
+            <li><a href="https://github.com/inexorabletash/text-encoding" target="_blank">text-encoding</a><span class="muted-color">, polyfill for the Encoding Living Standard's API, public domain</span></li>
+            <li><a href="https://github.com/jindw/xmldom" target="_blank">xmldom</a><span class="muted-color">, a pure JS W3C Standard based DOMParser and XMLSerializer</span></li>
+        </ul>
 
-    <h3>UI components</h3>
-    <ul>
-        <li><a href="https://github.com/Diokuz/baron" target="_blank">baron</a><span class="muted-color">, native scroll with custom scrollbar, &copy; 2018 Kuznetsov Dmitriy</span></li>
-        <li><a href="https://github.com/Pikaday/Pikaday" target="_blank">pikaday</a><span class="muted-color">, a refreshing JavaScript datepicker, &copy; 2014 David Bushell</span></li>
-    </ul>
+        <h3>UI components</h3>
+        <ul>
+            <li><a href="https://github.com/Diokuz/baron" target="_blank">baron</a><span class="muted-color">, native scroll with custom scrollbar, &copy; 2018 Kuznetsov Dmitriy</span></li>
+            <li><a href="https://github.com/Pikaday/Pikaday" target="_blank">pikaday</a><span class="muted-color">, a refreshing JavaScript datepicker, &copy; 2014 David Bushell</span></li>
+        </ul>
 
-    {{#if isDesktop}}
-    <h3>Desktop modules</h3>
-    <ul>
-        <li><a href="https://github.com/ranisalt/node-argon2" target="_blank">node-argon2</a><span class="muted-color">, node.js bindings for Argon2 hashing algorithm, &copy; 2015 Ranieri Althoff</span></li>
-        <li><a href="https://github.com/MadLittleMods/node-usb-detection" target="_blank">node-usb-detection</a><span class="muted-color">, list USB devices in system and detect changes on them, &copy; 2013 Kaba AG</span></li>
-        <li><a href="https://github.com/atom/node-keytar" target="_blank">node-keytar</a><span class="muted-color">, native password node module, &copy; 2013 GitHub Inc.</span></li>
-        <li><a href="https://github.com/antelle/node-yubikey-chalresp" target="_blank">node-yubikey-chalresp</a><span class="muted-color">, YubiKey challenge-response API for node.js, &copy; 2020 Antelle</span></li>
-        <li><a href="https://github.com/antelle/node-secure-enclave" target="_blank">node-secure-enclave</a><span class="muted-color">, Secure Enclave module for node.js and Electron, &copy; 2020 Antelle</span></li>
-        <li><a href="https://github.com/antelle/node-keyboard-auto-type" target="_blank">node-keyboard-auto-type</a><span class="muted-color">, node.js bindings for keyboard-auto-type, &copy; 2021 Antelle</span></li>
-    </ul>
-    {{/if}}
+        {{#if isDesktop}}
+        <h3>Desktop modules</h3>
+        <ul>
+            <li><a href="https://github.com/ranisalt/node-argon2" target="_blank">node-argon2</a><span class="muted-color">, node.js bindings for Argon2 hashing algorithm, &copy; 2015 Ranieri Althoff</span></li>
+            <li><a href="https://github.com/MadLittleMods/node-usb-detection" target="_blank">node-usb-detection</a><span class="muted-color">, list USB devices in system and detect changes on them, &copy; 2013 Kaba AG</span></li>
+            <li><a href="https://github.com/atom/node-keytar" target="_blank">node-keytar</a><span class="muted-color">, native password node module, &copy; 2013 GitHub Inc.</span></li>
+            <li><a href="https://github.com/antelle/node-yubikey-chalresp" target="_blank">node-yubikey-chalresp</a><span class="muted-color">, YubiKey challenge-response API for node.js, &copy; 2020 Antelle</span></li>
+            <li><a href="https://github.com/antelle/node-secure-enclave" target="_blank">node-secure-enclave</a><span class="muted-color">, Secure Enclave module for node.js and Electron, &copy; 2020 Antelle</span></li>
+            <li><a href="https://github.com/antelle/node-keyboard-auto-type" target="_blank">node-keyboard-auto-type</a><span class="muted-color">, node.js bindings for keyboard-auto-type, &copy; 2021 Antelle</span></li>
+        </ul>
+        {{/if}}
 
-    <h3>Utils</h3>
-    <ul>
-        <li><a href="https://marked.js.org/" target="_blank">marked</a><span class="muted-color">, a markdown parser and compiler, &copy; 2018+, MarkedJS (https://github.com/markedjs/) &copy; 2011-2018, Christopher Jeffrey (https://github.com/chjj/)</span></li>
-        <li><a href="https://github.com/cure53/DOMPurify" target="_blank">dompurify</a><span class="muted-color">, a DOM-only, super-fast, uber-tolerant XSS sanitizer, &copy; 2015 Mario Heiderich, </span>
-            <a href="{{licenseLinkApache}}" class="muted-color" target="_blank">Apache-2.0 license</a></li>
-        <li><a href="https://github.com/TomFrost/node-phonetic" target="_blank">node-phonetic</a><span class="muted-color">, generates unique, pronounceable names, &copy; 2013 Tom Frost</span></li>
-        <li><a href="https://github.com/LazarSoft/jsqrcode" target="_blank">jsqrcode</a><span class="muted-color">, javascript QR code scanner,
-            <a href="{{licenseLinkApache}}" class="muted-color" target="_blank">Apache-2.0 license</a></span></li>
-        <li><a href="https://tweetnacl.js.org/" target="_blank">tweetnacl.js</a><span class="muted-color">, port of TweetNaCl cryptographic library to JavaScript, public domain</span></li>
-    </ul>
+        <h3>Utils</h3>
+        <ul>
+            <li><a href="https://marked.js.org/" target="_blank">marked</a><span class="muted-color">, a markdown parser and compiler, &copy; 2018+, MarkedJS (https://github.com/markedjs/) &copy; 2011-2018, Christopher Jeffrey (https://github.com/chjj/)</span></li>
+            <li><a href="https://github.com/cure53/DOMPurify" target="_blank">dompurify</a><span class="muted-color">, a DOM-only, super-fast, uber-tolerant XSS sanitizer, &copy; 2015 Mario Heiderich, </span>
+                <a href="{{licenseLinkApache}}" class="muted-color" target="_blank">Apache-2.0 license</a></li>
+            <li><a href="https://github.com/TomFrost/node-phonetic" target="_blank">node-phonetic</a><span class="muted-color">, generates unique, pronounceable names, &copy; 2013 Tom Frost</span></li>
+            <li><a href="https://github.com/LazarSoft/jsqrcode" target="_blank">jsqrcode</a><span class="muted-color">, javascript QR code scanner,
+                <a href="{{licenseLinkApache}}" class="muted-color" target="_blank">Apache-2.0 license</a></span></li>
+            <li><a href="https://tweetnacl.js.org/" target="_blank">tweetnacl.js</a><span class="muted-color">, port of TweetNaCl cryptographic library to JavaScript, public domain</span></li>
+        </ul>
 
-    <h3>Styles</h3>
-    <ul>
-        <li><a href="https://sass-lang.com/" target="_blank">sass</a><span class="muted-color">, syntactically awesome stylesheets, &copy; 2012-2016 by the Sass Open Source Foundation</span></li>
-        <li><a href="https://bourbon.io/" target="_blank">bourbon</a><span class="muted-color">, a lightweight Sass tool set, &copy; 2011-2020 thoughtbot, inc. &lt;http://thoughtbot.com/&gt;</span></li>
-        <li><a href="https://github.com/thoughtbot/bitters" target="_blank">bitters</a><span class="muted-color">, a dash of pre-defined style to your Bourbon, &copy; 2013–2019 thoughtbot, inc. &lt;http://thoughtbot.com/&gt;</span></li>
-        <li><a href="https://necolas.github.io/normalize.css/" target="_blank">normalize.css</a><span class="muted-color">, a modern, HTML5-ready alternative to CSS resets, &copy; Nicolas Gallagher and Jonathan Neal</span></li>
-    </ul>
+        <h3>Styles</h3>
+        <ul>
+            <li><a href="https://sass-lang.com/" target="_blank">sass</a><span class="muted-color">, syntactically awesome stylesheets, &copy; 2012-2016 by the Sass Open Source Foundation</span></li>
+            <li><a href="https://bourbon.io/" target="_blank">bourbon</a><span class="muted-color">, a lightweight Sass tool set, &copy; 2011-2020 thoughtbot, inc. &lt;http://thoughtbot.com/&gt;</span></li>
+            <li><a href="https://github.com/thoughtbot/bitters" target="_blank">bitters</a><span class="muted-color">, a dash of pre-defined style to your Bourbon, &copy; 2013–2019 thoughtbot, inc. &lt;http://thoughtbot.com/&gt;</span></li>
+            <li><a href="https://necolas.github.io/normalize.css/" target="_blank">normalize.css</a><span class="muted-color">, a modern, HTML5-ready alternative to CSS resets, &copy; Nicolas Gallagher and Jonathan Neal</span></li>
+        </ul>
 
-    <h3>Graphics</h3>
-    <ul>
-        <li><a href="https://fontawesome.com/" target="_blank">fontawesome</a><span class="muted-color">, the iconic SVG, font, and CSS toolkit, </span>
-            <a href="{{licenseLinkCCBY40}}" class="muted-color" target="_blank">CC BY 4.0 License</a> <span class="muted-color">(icons only)</span></li>
-    </ul>
+        <h3>Graphics</h3>
+        <ul>
+            <li><a href="https://fontawesome.com/" target="_blank">fontawesome</a><span class="muted-color">, the iconic SVG, font, and CSS toolkit, </span>
+                <a href="{{licenseLinkCCBY40}}" class="muted-color" target="_blank">CC BY 4.0 License</a> <span class="muted-color">(icons only)</span></li>
+        </ul>
+    </section>
 
-    <h2>{{res 'setAboutLic'}}</h2>
-    <p>{{res 'setAboutLicComment'}}:</p>
-    <p>Copyright &copy; {{year}} Antelle https://antelle.net</p>
-    <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-        documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-        the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-        and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
-    <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
-    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-        THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-        OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-        ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+    <section class="settings__section">
+        <h2>{{res 'setAboutLic'}}</h2>
+        <p class="settings__meta">{{res 'setAboutLicComment'}}:</p>
+        <p class="settings__meta">Copyright &copy; {{year}} Antelle https://antelle.net</p>
+        <p class="settings__meta">Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+            documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+            the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+            and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+        <p class="settings__meta">The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+        <p class="settings__meta">THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+            THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+            OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+            ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+    </section>
 </div>

--- a/app/templates/settings/settings-browser.hbs
+++ b/app/templates/settings/settings-browser.hbs
@@ -1,189 +1,199 @@
-<div class="settings__content">
-    <h1><i class="fa fa-{{icon}} settings__head-icon"></i> {{res 'setBrowserTitle'}}</h1>
-    {{#if desktop}}
-        <p>{{res 'setBrowserIntroDesktop'}}</p>
-        <p>KeeWeb Connect: {{res 'setBrowserIntroKeeWebConnect'}}</p>
-        <p>KeePassXC-Browser: {{res 'setBrowserIntroKeePassXcBrowser'}}</p>
-        {{#if anyBrowserIsEnabled}}
-            <p>{{res 'setBrowserEnablePerBrowser'}}</p>
-        {{else}}
-            <p class="error-color">{{res 'setBrowserNotEnabled'}}</p>
-        {{/if}}
-        <table class="settings__browser-table">
-            <thead>
-                <tr>
-                    <th></th>
-                    {{#each extensionNames as |ext|}}
-                        <th>{{ext}}</th>
-                    {{/each}}
-                </tr>
-            </thead>
-            <tbody>
-                {{#each settingsPerBrowser as |perBrowser|}}
+<div class="settings__content settings__content--cards">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-{{icon}} settings__head-icon"></i> {{res 'setBrowserTitle'}}</h1>
+    </section>
+
+    <section class="settings__section">
+        {{#if desktop}}
+            <p class="settings__meta">{{res 'setBrowserIntroDesktop'}}</p>
+            <p class="settings__meta">KeeWeb Connect: {{res 'setBrowserIntroKeeWebConnect'}}</p>
+            <p class="settings__meta">KeePassXC-Browser: {{res 'setBrowserIntroKeePassXcBrowser'}}</p>
+            {{#if anyBrowserIsEnabled}}
+                <p class="settings__meta">{{res 'setBrowserEnablePerBrowser'}}</p>
+            {{else}}
+                <p class="error-color">{{res 'setBrowserNotEnabled'}}</p>
+            {{/if}}
+            <table class="settings__browser-table">
+                <thead>
                     <tr>
-                        <td>{{perBrowser.browserName}}</td>
-                        {{#each perBrowser.extensions as |setting|}}
-                            <td>
-                                {{#if setting.manualUrl}}
-                                    <a href="{{setting.manualUrl}}" target="_blank" rel="noreferrer"
-                                       class="settings__browser-extension-link icon-link"
-                                       title="{{res 'setBrowserExtensionHelp'}}"
-                                    >
-                                        <i class="fa fa-info-circle"></i>
-                                    </a>
-                                {{else}}
-                                    {{#if setting.supported}}
-                                        <input type="checkbox"
-                                               class="check-enable-for-browser"
-                                               {{#if setting.enabled}}checked{{/if}}
-                                               id="check-enable-{{setting.alias}}-for-{{perBrowser.browser}}"
-                                               data-browser="{{perBrowser.browser}}"
-                                               data-extension="{{setting.alias}}" />
-                                        <label for="check-enable-{{setting.alias}}-for-{{perBrowser.browser}}"></label>
-                                    {{else}}
-                                        <i class="fa fa-times muted-color" title="{{res 'setBrowserExtensionNotSupported'}}"></i>
-                                    {{/if}}
-                                    {{#if setting.enabled}}
-                                        {{#if setting.helpUrl}}
-                                            <a href="{{setting.helpUrl}}" target="_blank" rel="noreferrer"
-                                               class="settings__browser-extension-link icon-link"
-                                               title="{{res 'setBrowserExtensionHelp'}}"
-                                            >
-                                                <i class="fa fa-info-circle"></i>
-                                            </a>
-                                        {{/if}}
-                                        {{#if setting.installUrl}}
-                                            <a href="{{setting.installUrl}}" target="_blank" rel="noreferrer"
-                                               class="settings__browser-extension-link icon-link"
-                                               title="{{res 'setBrowserExtensionInstall'}}"
-                                            >
-                                                <i class="fa fa-download"></i>
-                                            </a>
-                                        {{/if}}
-                                    {{/if}}
-                                {{/if}}
-                            </td>
+                        <th></th>
+                        {{#each extensionNames as |ext|}}
+                            <th>{{ext}}</th>
                         {{/each}}
                     </tr>
-                {{/each}}
-            </tbody>
-        </table>
-    {{else}}
-        <p>{{res 'setBrowserIntroWeb'}}</p>
-        <a href="{{extensionDownloadLink}}" target="_blank" rel="noreferrer">
-            KeeWeb Connect {{#res 'setBrowserExtensionFor'}}{{extensionBrowserFamily}}{{/res}}
-        </a>
-    {{/if}}
-    <p></p>
+                </thead>
+                <tbody>
+                    {{#each settingsPerBrowser as |perBrowser|}}
+                        <tr>
+                            <td>{{perBrowser.browserName}}</td>
+                            {{#each perBrowser.extensions as |setting|}}
+                                <td>
+                                    {{#if setting.manualUrl}}
+                                        <a href="{{setting.manualUrl}}" target="_blank" rel="noreferrer"
+                                           class="settings__browser-extension-link icon-link"
+                                           title="{{res 'setBrowserExtensionHelp'}}"
+                                        >
+                                            <i class="fa fa-info-circle"></i>
+                                        </a>
+                                    {{else}}
+                                        {{#if setting.supported}}
+                                            <input type="checkbox"
+                                                   class="check-enable-for-browser"
+                                                   {{#if setting.enabled}}checked{{/if}}
+                                                   id="check-enable-{{setting.alias}}-for-{{perBrowser.browser}}"
+                                                   data-browser="{{perBrowser.browser}}"
+                                                   data-extension="{{setting.alias}}" />
+                                            <label for="check-enable-{{setting.alias}}-for-{{perBrowser.browser}}"></label>
+                                        {{else}}
+                                            <i class="fa fa-times muted-color" title="{{res 'setBrowserExtensionNotSupported'}}"></i>
+                                        {{/if}}
+                                        {{#if setting.enabled}}
+                                            {{#if setting.helpUrl}}
+                                                <a href="{{setting.helpUrl}}" target="_blank" rel="noreferrer"
+                                                   class="settings__browser-extension-link icon-link"
+                                                   title="{{res 'setBrowserExtensionHelp'}}"
+                                                >
+                                                    <i class="fa fa-info-circle"></i>
+                                                </a>
+                                            {{/if}}
+                                            {{#if setting.installUrl}}
+                                                <a href="{{setting.installUrl}}" target="_blank" rel="noreferrer"
+                                                   class="settings__browser-extension-link icon-link"
+                                                   title="{{res 'setBrowserExtensionInstall'}}"
+                                                >
+                                                    <i class="fa fa-download"></i>
+                                                </a>
+                                            {{/if}}
+                                        {{/if}}
+                                    {{/if}}
+                                </td>
+                            {{/each}}
+                        </tr>
+                    {{/each}}
+                </tbody>
+            </table>
+        {{else}}
+            <p class="settings__meta">{{res 'setBrowserIntroWeb'}}</p>
+            <a href="{{extensionDownloadLink}}" target="_blank" rel="noreferrer">
+                KeeWeb Connect {{#res 'setBrowserExtensionFor'}}{{extensionBrowserFamily}}{{/res}}
+            </a>
+        {{/if}}
+    </section>
 
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__browser-focus-if-locked"
-               id="settings__browser-focus-if-locked"
-               {{#if focusIfLocked}}checked{{/if}} />
-        <label for="settings__browser-focus-if-locked">{{res 'setBrowserFocusIfLocked'}}</label>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__browser-focus-if-empty"
-               id="settings__browser-focus-if-empty"
-               {{#if focusIfEmpty}}checked{{/if}} />
-        <label for="settings__browser-focus-if-empty">{{res 'setBrowserFocusIfEmpty'}}</label>
-    </div>
+    <section class="settings__section">
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__browser-focus-if-locked"
+                   id="settings__browser-focus-if-locked"
+                   {{#if focusIfLocked}}checked{{/if}} />
+            <label for="settings__browser-focus-if-locked">{{res 'setBrowserFocusIfLocked'}}</label>
+        </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__browser-focus-if-empty"
+                   id="settings__browser-focus-if-empty"
+                   {{#if focusIfEmpty}}checked{{/if}} />
+            <label for="settings__browser-focus-if-empty">{{res 'setBrowserFocusIfEmpty'}}</label>
+        </div>
+    </section>
 
-    <h2>{{res 'setBrowserSessions'}}</h2>
-    {{#if sessions.length}}
-        <p>{{res 'setBrowserSessionsIntro'}}</p>
+    <section class="settings__section">
+        <h2>{{res 'setBrowserSessions'}}</h2>
+        {{#if sessions.length}}
+            <p class="settings__meta">{{res 'setBrowserSessionsIntro'}}</p>
 
-        {{#each sessions as |session|}}
-            <h3>
-                <span class="settings__browser-extension-status
-                     {{#if session.permissions}}
-                         green-color
-                     {{else if session.permissionsDenied}}
-                         red-color
-                     {{else}}
-                         muted-color
-                     {{/if}}"
-                     title="
-                     {{~#if session.permissions~}}
-                         {{res 'setBrowserSessionsActiveTooltip'}}
-                     {{~else if session.permissionsDenied~}}
-                         {{res 'setBrowserSessionsDeniedTooltip'}}
-                     {{~else~}}
-                         {{res 'setBrowserSessionsInactiveTooltip'}}
-                     {{/if}}"
-                ></span>
-                {{session.extensionName}}{{#if session.appName}} ({{session.appName}}){{/if}}
-            </h3>
-            <p>{{res 'setBrowserSessionsConnectedDate'}}: {{session.connectedDate}}</p>
-            <p>
-                {{#if session.permissions}}
-                    {{res 'setBrowserSessionsActiveText'}}
-                {{else if session.permissionsDenied}}
-                    {{res 'setBrowserSessionsDeniedText'}}
-                {{else}}
-                    {{res 'setBrowserSessionsInactiveText'}}
-                {{/if}}
-            </p>
-            {{#if session.permissions}}
-                <div>
-                    <label>{{res 'setBrowserSessionsAccessToFiles'}}:</label>
-                    <div class="settings__browser-session-files">
-                        {{#each session.fileAccess as |file|}}
-                            <div class="settings__browser-session-file">
-                                <input type="checkbox" class="input-base settings__browser-session-file-check"
-                                       data-client-id="{{session.clientId}}"
-                                       data-file-id="{{file.id}}"
-                                       id="settings__browser-session-file-check--{{file.id}}"
-                                       {{#if file.checked}}checked{{/if}}
-                                />
-                                <label for="settings__browser-session-file-check--{{file.id}}">{{file.name}}</label>
+            {{#each sessions as |session|}}
+                <div class="settings__browser-session-card">
+                    <h3>
+                        <span class="settings__browser-extension-status
+                             {{#if session.permissions}}
+                                 green-color
+                             {{else if session.permissionsDenied}}
+                                 red-color
+                             {{else}}
+                                 muted-color
+                             {{/if}}"
+                             title="
+                             {{~#if session.permissions~}}
+                                 {{res 'setBrowserSessionsActiveTooltip'}}
+                             {{~else if session.permissionsDenied~}}
+                                 {{res 'setBrowserSessionsDeniedTooltip'}}
+                             {{~else~}}
+                                 {{res 'setBrowserSessionsInactiveTooltip'}}
+                             {{/if}}"
+                        ></span>
+                        {{session.extensionName}}{{#if session.appName}} ({{session.appName}}){{/if}}
+                    </h3>
+                    <p class="settings__meta">{{res 'setBrowserSessionsConnectedDate'}}: {{session.connectedDate}}</p>
+                    <p class="settings__meta">
+                        {{#if session.permissions}}
+                            {{res 'setBrowserSessionsActiveText'}}
+                        {{else if session.permissionsDenied}}
+                            {{res 'setBrowserSessionsDeniedText'}}
+                        {{else}}
+                            {{res 'setBrowserSessionsInactiveText'}}
+                        {{/if}}
+                    </p>
+                    {{#if session.permissions}}
+                        <div class="settings__field settings__field--stack">
+                            <label>{{res 'setBrowserSessionsAccessToFiles'}}:</label>
+                            <div class="settings__browser-session-files">
+                                {{#each session.fileAccess as |file|}}
+                                    <div class="settings__browser-session-file">
+                                        <input type="checkbox" class="input-base settings__browser-session-file-check"
+                                               data-client-id="{{session.clientId}}"
+                                               data-file-id="{{file.id}}"
+                                               id="settings__browser-session-file-check--{{file.id}}"
+                                               {{#if file.checked}}checked{{/if}}
+                                        />
+                                        <label for="settings__browser-session-file-check--{{file.id}}">{{file.name}}</label>
+                                    </div>
+                                {{/each}}
                             </div>
-                        {{/each}}
+                        </div>
+                        {{#if session.noFileAccess}}
+                            <p class="error-color">{{res 'setBrowserSessionsNoFileAccess'}}</p>
+                        {{/if}}
+                        <div class="settings__field">
+                            <label for="settings__browser-session-ask-get--{{session.connectionId}}">{{res 'extensionConnectAskGet'}}</label>
+                            <select id="settings__browser-session-ask-get--{{session.connectionId}}"
+                                    data-client-id="{{session.clientId}}"
+                                    class="settings__browser-session-ask-get settings__select input-base">
+                                <option value="multiple" {{#ifeq session.permissions.askGet 'multiple'}}selected{{/ifeq}}>
+                                    {{res 'extensionConnectAskGetMultiple'}}
+                                </option>
+                                <option value="always" {{#ifeq session.permissions.askGet 'always'}}selected{{/ifeq}}>
+                                    {{res 'extensionConnectAskGetAlways'}}
+                                </option>
+                            </select>
+                        </div>
+                        {{#if session.showAskSave}}
+                            <div class="settings__field">
+                                <label for="settings__browser-session-ask-save--{{session.connectionId}}">{{res 'extensionConnectAskSave'}}</label>
+                                <select id="settings__browser-session-ask-save--{{session.connectionId}}"
+                                        data-client-id="{{session.clientId}}"
+                                        class="settings__browser-session-ask-save settings__select input-base">
+                                    <option value="always" {{#ifeq session.permissions.askSave 'always'}}selected{{/ifeq}}>
+                                        {{res 'extensionConnectAskSaveAlways'}}
+                                    </option>
+                                    <option value="auto" {{#ifeq session.permissions.askSave 'auto'}}selected{{/ifeq}}>
+                                        {{res 'extensionConnectAskSaveAuto'}}
+                                    </option>
+                                </select>
+                            </div>
+                        {{/if}}
+                        <p class="settings__meta">{{res 'setBrowserSessionsPasswordsRead'}}: {{session.passwordsRead}}</p>
+                        {{#if session.passwordsWritten}}<p class="settings__meta">{{res 'setBrowserSessionsPasswordsWritten'}}: {{session.passwordsWritten}}</p>{{/if}}
+                    {{/if}}
+                    <div class="settings__browser-session-buttons">
+                        {{#if ../desktop}}
+                            <button class="btn btn-error settings__browser-btn-terminate-session"
+                                    data-connection-id="{{session.connectionId}}"
+                            >{{res 'setBrowserSessionsTerminate'}}</button>
+                        {{/if}}
                     </div>
                 </div>
-                {{#if session.noFileAccess}}
-                    <p class="error-color">{{res 'setBrowserSessionsNoFileAccess'}}</p>
-                {{/if}}
-                <div>
-                    <label for="settings__browser-session-ask-get--{{session.connectionId}}">{{res 'extensionConnectAskGet'}}</label>
-                    <select id="settings__browser-session-ask-get--{{session.connectionId}}"
-                            data-client-id="{{session.clientId}}"
-                            class="settings__browser-session-ask-get settings__select input-base">
-                        <option value="multiple" {{#ifeq session.permissions.askGet 'multiple'}}selected{{/ifeq}}>
-                            {{res 'extensionConnectAskGetMultiple'}}
-                        </option>
-                        <option value="always" {{#ifeq session.permissions.askGet 'always'}}selected{{/ifeq}}>
-                            {{res 'extensionConnectAskGetAlways'}}
-                        </option>
-                    </select>
-                </div>
-                {{#if session.showAskSave}}
-                    <div>
-                        <label for="settings__browser-session-ask-save--{{session.connectionId}}">{{res 'extensionConnectAskSave'}}</label>
-                        <select id="settings__browser-session-ask-save--{{session.connectionId}}"
-                                data-client-id="{{session.clientId}}"
-                                class="settings__browser-session-ask-save settings__select input-base">
-                            <option value="always" {{#ifeq session.permissions.askSave 'always'}}selected{{/ifeq}}>
-                                {{res 'extensionConnectAskSaveAlways'}}
-                            </option>
-                            <option value="auto" {{#ifeq session.permissions.askSave 'auto'}}selected{{/ifeq}}>
-                                {{res 'extensionConnectAskSaveAuto'}}
-                            </option>
-                        </select>
-                    </div>
-                {{/if}}
-                <p>{{res 'setBrowserSessionsPasswordsRead'}}: {{session.passwordsRead}}</p>
-                {{#if session.passwordsWritten}}<p>{{res 'setBrowserSessionsPasswordsWritten'}}: {{session.passwordsWritten}}</p>{{/if}}
-            {{/if}}
-            <div class="settings__browser-session-buttons">
-                {{#if ../desktop}}
-                    <button class="btn btn-error settings__browser-btn-terminate-session"
-                            data-connection-id="{{session.connectionId}}"
-                    >{{res 'setBrowserSessionsTerminate'}}</button>
-                {{/if}}
-            </div>
-        {{/each}}
-    {{else}}
-        <p>{{res 'setBrowserSessionsEmpty'}}</p>
-    {{/if}}
+            {{/each}}
+        {{else}}
+            <p class="settings__meta">{{res 'setBrowserSessionsEmpty'}}</p>
+        {{/if}}
+    </section>
 </div>

--- a/app/templates/settings/settings-devices.hbs
+++ b/app/templates/settings/settings-devices.hbs
@@ -1,56 +1,65 @@
-<div class="settings__content">
-    <h1><i class="fa fa-usb settings__head-icon"></i> {{res 'setDevicesTitle'}}</h1>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__devices-enable-usb" id="settings__devices-enable-usb"
-               {{#if enableUsb}}checked{{/if}} {{#unless supported}}disabled{{/unless}} />
-        <label for="settings__devices-enable-usb">{{res 'setDevicesEnableUsb'}}</label>
-    </div>
+<div class="settings__content settings__content--cards">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-usb settings__head-icon"></i> {{res 'setDevicesTitle'}}</h1>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__devices-enable-usb" id="settings__devices-enable-usb"
+                   {{#if enableUsb}}checked{{/if}} {{#unless supported}}disabled{{/unless}} />
+            <label for="settings__devices-enable-usb">{{res 'setDevicesEnableUsb'}}</label>
+        </div>
+    </section>
 
     {{#if enableUsb}}
-        <h2>YubiKey</h2>
-        <p>{{#res 'setDevicesYubiKeyIntro'}}<a href="{{yubiKeyManualLink}}" target="_blank">{{res 'setDevicesYubiKeyIntroLink'}}</a>{{/res}}</p>
-        <h3>{{res 'setDevicesYubiKeyOtpTitle'}}</h3>
-        <p>{{res 'setDevicesYubiKeyOtpDesc'}}</p>
-        <p>
-            {{#res 'setDevicesYubiKeyToolsDesc'}}<code>ykman</code>{{/res}}
-            {{#res 'setDevicesYubiKeyToolsDesc2'}}<a href="{{ykmanInstallLink}}" target="_blank">{{res 'setDevicesYubiKeyToolsDescLink'}}</a>{{/res}}
-        </p>
-        <p>
-            {{#ifeq ykmanStatus 'checking'}}{{#res 'setDevicesYubiKeyToolsStatusChecking'}}<code>ykman</code>{{/res}}...{{/ifeq}}
-            {{#ifeq ykmanStatus 'ok'}}{{#res 'setDevicesYubiKeyToolsStatusOk'}}<code>ykman</code>{{/res}}{{/ifeq}}
-            {{#ifeq ykmanStatus 'error'}}{{#res 'setDevicesYubiKeyToolsStatusError'}}<code>ykman</code>{{/res}}{{/ifeq}}
-        </p>
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__yubikey-show-icon" id="settings__yubikey-show-icon"
-                   {{#if yubiKeyShowIcon}}checked{{/if}} />
-            <label for="settings__yubikey-show-icon">{{res 'setDevicesYubiKeyOtpShowIcon'}}</label>
-        </div>
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__yubikey-match-entries" id="settings__yubikey-match-entries"
-                   {{#if yubiKeyMatchEntries}}checked{{/if}} />
-            <label for="settings__yubikey-match-entries">{{res 'setDevicesYubiKeyOtpMatchEntries'}}</label>
-        </div>
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__yubikey-auto-open" id="settings__yubikey-auto-open"
-                   {{#if yubiKeyAutoOpen}}checked{{/if}} />
-            <label for="settings__yubikey-auto-open">{{res 'setDevicesYubiKeyOtpAutoOpen'}}</label>
-        </div>
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__yubikey-stuck-workaround" id="settings__yubikey-stuck-workaround"
-                   {{#if yubiKeyStuckWorkaround}}checked{{/if}} />
-            <label for="settings__yubikey-stuck-workaround">{{res 'setDevicesYubiKeyStuckWorkaround'}}</label>
-        </div>
-        <h3>{{res 'setDevicesYubiKeyChalRespTitle'}}</h3>
-        <p>{{res 'setDevicesYubiKeyChalRespDesc'}}</p>
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__yubikey-chalresp-show" id="settings__yubikey-chalresp-show"
-                   {{#if yubiKeyShowChalResp}}checked{{/if}} />
-            <label for="settings__yubikey-chalresp-show">{{res 'setDevicesYubiKeyChalRespShow'}}</label>
-        </div>
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__yubikey-remember-chalresp" id="settings__yubikey-remember-chalresp"
-                   {{#if yubiKeyRememberChalResp}}checked{{/if}} />
-            <label for="settings__yubikey-remember-chalresp">{{res 'setDevicesYubiKeyRememberChalResp'}}</label>
-        </div>
+        <section class="settings__section">
+            <h2>YubiKey</h2>
+            <p class="settings__meta">{{#res 'setDevicesYubiKeyIntro'}}<a href="{{yubiKeyManualLink}}" target="_blank">{{res 'setDevicesYubiKeyIntroLink'}}</a>{{/res}}</p>
+
+            <h3>{{res 'setDevicesYubiKeyOtpTitle'}}</h3>
+            <p class="settings__meta">{{res 'setDevicesYubiKeyOtpDesc'}}</p>
+            <p class="settings__meta">
+                {{#res 'setDevicesYubiKeyToolsDesc'}}<code>ykman</code>{{/res}}
+                {{#res 'setDevicesYubiKeyToolsDesc2'}}<a href="{{ykmanInstallLink}}" target="_blank">{{res 'setDevicesYubiKeyToolsDescLink'}}</a>{{/res}}
+            </p>
+            <p class="settings__meta">
+                {{#ifeq ykmanStatus 'checking'}}{{#res 'setDevicesYubiKeyToolsStatusChecking'}}<code>ykman</code>{{/res}}...{{/ifeq}}
+                {{#ifeq ykmanStatus 'ok'}}{{#res 'setDevicesYubiKeyToolsStatusOk'}}<code>ykman</code>{{/res}}{{/ifeq}}
+                {{#ifeq ykmanStatus 'error'}}{{#res 'setDevicesYubiKeyToolsStatusError'}}<code>ykman</code>{{/res}}{{/ifeq}}
+            </p>
+
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__yubikey-show-icon" id="settings__yubikey-show-icon"
+                       {{#if yubiKeyShowIcon}}checked{{/if}} />
+                <label for="settings__yubikey-show-icon">{{res 'setDevicesYubiKeyOtpShowIcon'}}</label>
+            </div>
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__yubikey-match-entries" id="settings__yubikey-match-entries"
+                       {{#if yubiKeyMatchEntries}}checked{{/if}} />
+                <label for="settings__yubikey-match-entries">{{res 'setDevicesYubiKeyOtpMatchEntries'}}</label>
+            </div>
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__yubikey-auto-open" id="settings__yubikey-auto-open"
+                       {{#if yubiKeyAutoOpen}}checked{{/if}} />
+                <label for="settings__yubikey-auto-open">{{res 'setDevicesYubiKeyOtpAutoOpen'}}</label>
+            </div>
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__yubikey-stuck-workaround" id="settings__yubikey-stuck-workaround"
+                       {{#if yubiKeyStuckWorkaround}}checked{{/if}} />
+                <label for="settings__yubikey-stuck-workaround">{{res 'setDevicesYubiKeyStuckWorkaround'}}</label>
+            </div>
+        </section>
+
+        <section class="settings__section">
+            <h2>{{res 'setDevicesYubiKeyChalRespTitle'}}</h2>
+            <p class="settings__meta">{{res 'setDevicesYubiKeyChalRespDesc'}}</p>
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__yubikey-chalresp-show" id="settings__yubikey-chalresp-show"
+                       {{#if yubiKeyShowChalResp}}checked{{/if}} />
+                <label for="settings__yubikey-chalresp-show">{{res 'setDevicesYubiKeyChalRespShow'}}</label>
+            </div>
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__yubikey-remember-chalresp" id="settings__yubikey-remember-chalresp"
+                       {{#if yubiKeyRememberChalResp}}checked{{/if}} />
+                <label for="settings__yubikey-remember-chalresp">{{res 'setDevicesYubiKeyRememberChalResp'}}</label>
+            </div>
+        </section>
     {{/if}}
 </div>

--- a/app/templates/settings/settings-file.hbs
+++ b/app/templates/settings/settings-file.hbs
@@ -1,205 +1,266 @@
-<div class="settings__content">
-    <h1><i class="fa fa-lock settings__head-icon"></i> {{name}}</h1>
-    {{#if storage}}
-        {{#ifeq storage 'file'}}<p>{{res 'setFilePath'}}: {{path}}</p>{{/ifeq}}
-        {{#ifneq storage 'file'}}<p>{{#res 'setFileStorage'}}{{res storage}}{{/res}}</p>{{/ifneq}}
-    {{else}}
-        <p>{{res 'setFileIntl'}}.</p>
-        {{#unless supportFiles}}
-            <p>{{res 'setFileLocalHint'}} <a href="{{desktopLink}}" target="_blank">{{res 'setFileDownloadApp'}}</a></p>
-        {{/unless}}
-    {{/if}}
-
-    <div class="settings__file-buttons">
-        <button class="settings__file-button-save-default" {{#if syncing}}disabled{{/if}}>
-            {{#ifeq storage 'file'}}{{res 'setFileSave'}}{{/ifeq}}
-            {{#ifneq storage 'file'}}{{res 'setFileSyncVerb'}}{{/ifneq}}
-        </button>
-        {{#if canSaveTo}}
-            <button class="settings__file-button-save-choose btn-silent"
-                {{#if syncing}}disabled{{/if}}>{{res 'setFileSaveTo'}}</button>
-        {{/if}}
-        <button class="settings__file-button-close btn-silent">{{res 'setFileClose'}}</button>
-    </div>
-
-    <div class="settings__file-save-choose hide">
-        <h2>{{res 'setFileSaveTo'}}</h2>
-        {{#ifneq storage 'file'}}
-        <div class="settings__file-save-to settings__file-save-to-file">
-            <i class="fa fa-file-alt"></i>{{Res 'file'}}
-        </div>
-        {{/ifneq}}
-        {{#each storageProviders as |prv|}}
-            {{#unless prv.own}}
-            <div class="settings__file-save-to settings__file-save-to-storage" data-storage="{{prv.name}}">
-                {{#if prv.icon}}<i class="fa fa-{{prv.icon}}"></i>{{/if}}
-                <span>{{res prv.name}}</span>
-            </div>
+<div class="settings__content settings__content--file">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-lock settings__head-icon"></i> {{name}}</h1>
+        {{#if storage}}
+            {{#ifeq storage 'file'}}<p class="settings__meta">{{res 'setFilePath'}}: {{path}}</p>{{/ifeq}}
+            {{#ifneq storage 'file'}}<p class="settings__meta">{{#res 'setFileStorage'}}{{res storage}}{{/res}}</p>{{/ifneq}}
+        {{else}}
+            <p class="settings__meta">{{res 'setFileIntl'}}.</p>
+            {{#unless supportFiles}}
+                <p class="settings__meta">{{res 'setFileLocalHint'}} <a href="{{desktopLink}}" target="_blank">{{res 'setFileDownloadApp'}}</a></p>
             {{/unless}}
-        {{/each}}
-        {{#if canExportXml}}
-        <div class="settings__file-save-to settings__file-save-to-xml">
-            <i class="fa fa-code"></i>{{res 'setFileSaveToXml'}}
+        {{/if}}
+
+        <div class="settings__file-buttons">
+            <button class="settings__file-button-save-default" {{#if syncing}}disabled{{/if}}>
+                {{#ifeq storage 'file'}}{{res 'setFileSave'}}{{/ifeq}}
+                {{#ifneq storage 'file'}}{{res 'setFileSyncVerb'}}{{/ifneq}}
+            </button>
+            {{#if canSaveTo}}
+                <button class="settings__file-button-save-choose btn-silent"
+                    {{#if syncing}}disabled{{/if}}>{{res 'setFileSaveTo'}}</button>
+            {{/if}}
+            <button class="settings__file-button-close btn-silent">{{res 'setFileClose'}}</button>
         </div>
-        {{/if}}
-        {{#if canExportHtml}}
-            <div class="settings__file-save-to settings__file-save-to-html">
-                <i class="fa fa-html5"></i>{{res 'setFileSaveToHtml'}}
+
+        <div class="settings__file-save-choose hide">
+            <h3 class="settings__section-subtitle">{{res 'setFileSaveTo'}}</h3>
+            {{#ifneq storage 'file'}}
+            <div class="settings__file-save-to settings__file-save-to-file">
+                <i class="fa fa-file-alt"></i>{{Res 'file'}}
             </div>
-        {{/if}}
-    </div>
+            {{/ifneq}}
+            {{#each storageProviders as |prv|}}
+                {{#unless prv.own}}
+                <div class="settings__file-save-to settings__file-save-to-storage" data-storage="{{prv.name}}">
+                    {{#if prv.icon}}<i class="fa fa-{{prv.icon}}"></i>{{/if}}
+                    <span>{{res prv.name}}</span>
+                </div>
+                {{/unless}}
+            {{/each}}
+            {{#if canExportXml}}
+            <div class="settings__file-save-to settings__file-save-to-xml">
+                <i class="fa fa-code"></i>{{res 'setFileSaveToXml'}}
+            </div>
+            {{/if}}
+            {{#if canExportHtml}}
+                <div class="settings__file-save-to settings__file-save-to-html">
+                    <i class="fa fa-html5"></i>{{res 'setFileSaveToHtml'}}
+                </div>
+            {{/if}}
+        </div>
+    </section>
 
     {{#if storage}}
-    <h2>{{res 'setFileSync'}}</h2>
-    <div>{{res 'setFileLastSync'}}: {{#if syncDate}}{{syncDate}}{{else}}{{res 'setFileLastSyncUnknown'}}{{/if}} {{#if syncing}}({{res 'setFileSyncInProgress'}}...){{/if}}</div>
-    {{#if syncError}}<div>{{res 'setFileSyncError'}}: {{syncError}}</div>{{/if}}
+    <section class="settings__section" id="sync">
+        <h2>{{res 'setFileSync'}}</h2>
+        <p class="settings__meta">{{res 'setFileLastSync'}}: {{#if syncDate}}{{syncDate}}{{else}}{{res 'setFileLastSyncUnknown'}}{{/if}} {{#if syncing}}({{res 'setFileSyncInProgress'}}...){{/if}}</p>
+        {{#if syncError}}<p class="settings__error">{{res 'setFileSyncError'}}: {{syncError}}</p>{{/if}}
+    </section>
     {{/if}}
 
-    <h2>{{res 'settings'}}</h2>
-    <label for="settings__file-master-pass" class="settings__file-master-pass-label input-base">{{res 'setFilePass'}}:
-        <span class="settings__file-master-pass-warning">
-            <i class="fa fa-exclamation-triangle"></i> <span id="settings__file-master-pass-warning-text">{{res 'setFilePassChange'}}</span>
-        </span>
-    </label>
-    <div class="hide">
-        {{!-- we need these inputs to screw browsers passwords autocompletion --}}
-        <input type="text" name="username">
-        <input type="password" name="password">
-    </div>
-    <input type="password" class="settings__input input-base" id="settings__file-master-pass" value="{{password}}" autocomplete="new-password" />
-    <div id="settings__file-confirm-master-pass-group">
-        <label for="settings__file-confirm-master-pass" class="settings__file-master-pass-label input-base">{{res 'setFileConfirmPass'}}:
-            <span class="settings__file-confirm-master-pass-warning">
-                <i class="fa fa-exclamation-triangle"></i> {{res 'setFilePassNotMatch'}}
-            </span>
-        </label>
-        <input type="password" class="settings__input input-base" id="settings__file-confirm-master-pass" autocomplete="confirm-password" />
-    </div>
-    <p>
-        <label for="settings__file-key-file">{{res 'setFileKeyFile'}}:</label>
-        <select class="settings__select settings__select-no-margin input-base" id="settings__file-key-file"></select>
-        <a id="settings__file-file-select-link">{{res 'setFileSelKeyFile'}}</a>
-        <input type="file" id="settings__file-file-select" class="hide-by-pos" />
-    </p>
-    {{#if showYubiKeyBlock}}
-        <p>
-            <label for="settings__file-yubikey">{{res 'setFileYubiKey'}}:</label>
-            <select class="settings__select settings__select-no-margin input-base" id="settings__file-yubikey">
-                <option value="" {{#unless selectedYubiKey}}selected{{/unless}}>{{res 'setFileDontUseYubiKey'}}</option>
-                {{#each yubiKeys as |yk|}}
-                    <option value="{{yk.value}}"
-                            {{#ifeq ../selectedYubiKey yk.value}}selected{{/ifeq}}
-                            data-vid="{{yk.vid}}"
-                            data-pid="{{yk.pid}}"
-                            data-serial="{{yk.serial}}"
-                            data-slot="{{yk.slot}}"
-                    >
-                        {{yk.fullName}}, {{res 'yubiKeySlot'}} {{yk.slot}}
-                    </option>
-                {{/each}}
-                <option value="refresh">{{res 'setFileRefreshYubiKeyList'}}</option>
-            </select>
-        </p>
-    {{/if}}
+    <section class="settings__section" id="settings">
+        <h2>{{res 'settings'}}</h2>
+        <div class="settings__field">
+            <label for="settings__file-master-pass" class="settings__file-master-pass-label input-base">{{res 'setFilePass'}}:
+                <span class="settings__file-master-pass-warning">
+                    <i class="fa fa-exclamation-triangle"></i> <span id="settings__file-master-pass-warning-text">{{res 'setFilePassChange'}}</span>
+                </span>
+            </label>
+            <div class="settings__field-controls">
+                <div class="hide">
+                    {{!-- we need these inputs to screw browsers passwords autocompletion --}}
+                    <input type="text" name="username">
+                    <input type="password" name="password">
+                </div>
+                <input type="password" class="settings__input input-base" id="settings__file-master-pass" value="{{password}}" autocomplete="new-password" />
+                <div id="settings__file-confirm-master-pass-group">
+                    <label for="settings__file-confirm-master-pass" class="settings__file-master-pass-label input-base">{{res 'setFileConfirmPass'}}:
+                        <span class="settings__file-confirm-master-pass-warning">
+                            <i class="fa fa-exclamation-triangle"></i> {{res 'setFilePassNotMatch'}}
+                        </span>
+                    </label>
+                    <input type="password" class="settings__input input-base" id="settings__file-confirm-master-pass" autocomplete="confirm-password" />
+                </div>
+            </div>
+        </div>
 
-    <h2>{{res 'setFileNames'}}</h2>
-    <label for="settings__file-name">{{Res 'name'}}:</label>
-    <input type="text" class="settings__input input-base" id="settings__file-name" value="{{name}}" required />
-    <label for="settings__file-def-user">{{res 'setFileDefUser'}}:</label>
-    <input type="text" class="settings__input input-base" id="settings__file-def-user" value="{{defaultUser}}" />
+        <div class="settings__field">
+            <label for="settings__file-key-file">{{res 'setFileKeyFile'}}:</label>
+            <div class="settings__field-controls">
+                <select class="settings__select settings__select-no-margin input-base" id="settings__file-key-file"></select>
+                <a id="settings__file-file-select-link">{{res 'setFileSelKeyFile'}}</a>
+                <input type="file" id="settings__file-file-select" class="hide-by-pos" />
+            </div>
+        </div>
+
+        {{#if showYubiKeyBlock}}
+            <div class="settings__field">
+                <label for="settings__file-yubikey">{{res 'setFileYubiKey'}}:</label>
+                <div class="settings__field-controls">
+                    <select class="settings__select settings__select-no-margin input-base" id="settings__file-yubikey">
+                        <option value="" {{#unless selectedYubiKey}}selected{{/unless}}>{{res 'setFileDontUseYubiKey'}}</option>
+                        {{#each yubiKeys as |yk|}}
+                            <option value="{{yk.value}}"
+                                    {{#ifeq ../selectedYubiKey yk.value}}selected{{/ifeq}}
+                                    data-vid="{{yk.vid}}"
+                                    data-pid="{{yk.pid}}"
+                                    data-serial="{{yk.serial}}"
+                                    data-slot="{{yk.slot}}"
+                            >
+                                {{yk.fullName}}, {{res 'yubiKeySlot'}} {{yk.slot}}
+                            </option>
+                        {{/each}}
+                        <option value="refresh">{{res 'setFileRefreshYubiKeyList'}}</option>
+                    </select>
+                </div>
+            </div>
+        {{/if}}
+    </section>
+
+    <section class="settings__section" id="names">
+        <h2>{{res 'setFileNames'}}</h2>
+        <div class="settings__field">
+            <label for="settings__file-name">{{Res 'name'}}:</label>
+            <input type="text" class="settings__input input-base" id="settings__file-name" value="{{name}}" required />
+        </div>
+        <div class="settings__field">
+            <label for="settings__file-def-user">{{res 'setFileDefUser'}}:</label>
+            <input type="text" class="settings__input input-base" id="settings__file-def-user" value="{{defaultUser}}" />
+        </div>
+    </section>
 
     {{#if canBackup}}
-    <h2>{{res 'setFileBackups'}}</h2>
-    <div>
-        <input type="checkbox" class="settings__input input-base" id="settings__file-backup-enabled" {{#if backupEnabled}}checked{{/if}} />
-        <label for="settings__file-backup-enabled">{{res 'setFileBackupEnable'}}</label>
-    </div>
-    <div class="settings__file-backups {{#unless backupEnabled}}hide{{/unless}}">
-        <select class="settings__select input-base" id="settings__file-backup-storage">
-            {{#if supportFiles}}<option value="file" {{#ifeq backupStorage 'file'}}selected{{/ifeq}}>{{Res 'file'}}</option>{{/if}}
-            {{#each storageProviders as |prv|}}
-                {{#if prv.backup}}
-                <option value="{{prv.name}}" {{#ifeq ../backupStorage prv.name}}selected{{/ifeq}}>{{res prv.name}}</option>
-                {{/if}}
-            {{/each}}
-        </select>
-        <label for="settings__file-backup-path">{{res 'setFileBackupPath'}}:</label>
-        <input type="text" class="settings__input input-base" id="settings__file-backup-path" value="{{backupPath}}"
-            placeholder="{{backupPath}}" />
-        <label for="settings__file-backup-schedule">{{res 'setFileBackupTime'}}:</label>
-        <select class="settings__select input-base" id="settings__file-backup-schedule">
-            <option value="0" {{#ifeq backupSchedule '0'}}selected{{/ifeq}}>{{res 'setFileBackupOnSave'}}</option>
-            <option value="1d" {{#ifeq backupSchedule '1d'}}selected{{/ifeq}}>{{res 'setFileBackupDaily'}}</option>
-            <option value="1w" {{#ifeq backupSchedule '1w'}}selected{{/ifeq}}>{{res 'setFileBackupWeekly'}}</option>
-            <option value="1m" {{#ifeq backupSchedule '1m'}}selected{{/ifeq}}>{{res 'setFileBackupMonthly'}}</option>
-            <option value="" {{#unless backupSchedule}}selected{{/unless}}>{{res 'setFileBackupManually'}}</option>
-        </select>
-        <button class="btn-silent settings__file-button-backup">{{res 'setFileBackupNow'}}</button>
-    </div>
+    <section class="settings__section" id="backups">
+        <h2>{{res 'setFileBackups'}}</h2>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base" id="settings__file-backup-enabled" {{#if backupEnabled}}checked{{/if}} />
+            <label for="settings__file-backup-enabled">{{res 'setFileBackupEnable'}}</label>
+        </div>
+        <div class="settings__file-backups {{#unless backupEnabled}}hide{{/unless}}">
+            <div class="settings__field">
+                <label for="settings__file-backup-storage">{{Res 'storage'}}:</label>
+                <div class="settings__field-controls">
+                    <select class="settings__select input-base" id="settings__file-backup-storage">
+                        {{#if supportFiles}}<option value="file" {{#ifeq backupStorage 'file'}}selected{{/ifeq}}>{{Res 'file'}}</option>{{/if}}
+                        {{#each storageProviders as |prv|}}
+                            {{#if prv.backup}}
+                            <option value="{{prv.name}}" {{#ifeq ../backupStorage prv.name}}selected{{/ifeq}}>{{res prv.name}}</option>
+                            {{/if}}
+                        {{/each}}
+                    </select>
+                </div>
+            </div>
+            <div class="settings__field">
+                <label for="settings__file-backup-path">{{res 'setFileBackupPath'}}:</label>
+                <input type="text" class="settings__input input-base" id="settings__file-backup-path" value="{{backupPath}}"
+                    placeholder="{{backupPath}}" />
+            </div>
+            <div class="settings__field">
+                <label for="settings__file-backup-schedule">{{res 'setFileBackupTime'}}:</label>
+                <div class="settings__field-controls">
+                    <select class="settings__select input-base" id="settings__file-backup-schedule">
+                        <option value="0" {{#ifeq backupSchedule '0'}}selected{{/ifeq}}>{{res 'setFileBackupOnSave'}}</option>
+                        <option value="1d" {{#ifeq backupSchedule '1d'}}selected{{/ifeq}}>{{res 'setFileBackupDaily'}}</option>
+                        <option value="1w" {{#ifeq backupSchedule '1w'}}selected{{/ifeq}}>{{res 'setFileBackupWeekly'}}</option>
+                        <option value="1m" {{#ifeq backupSchedule '1m'}}selected{{/ifeq}}>{{res 'setFileBackupMonthly'}}</option>
+                        <option value="" {{#unless backupSchedule}}selected{{/unless}}>{{res 'setFileBackupManually'}}</option>
+                    </select>
+                </div>
+            </div>
+            <button class="btn-silent settings__file-button-backup">{{res 'setFileBackupNow'}}</button>
+        </div>
+    </section>
     {{/if}}
 
-    <h2>{{Res 'history'}}</h2>
-    <div>
-        <input type="checkbox" class="settings__input input-base" id="settings__file-trash" {{#if recycleBinEnabled}}checked{{/if}} />
-        <label for="settings__file-trash">{{res 'setFileEnableTrash'}}</label>
-    </div>
-    <label for="settings__file-hist-type">{{res 'setFileHistMode'}}</label>
-    <select class="settings__select input-base" id="settings__file-hist-type">
-        <option value="1" {{#cmp historyMaxItems 0 '>'}}selected{{/cmp}}>{{res 'setFileHistLimited'}}</option>
-        <option value="0" {{#ifeq historyMaxItems 0}}selected{{/ifeq}}>{{res 'setFileHistDisabled'}}</option>
-        <option value="-1" {{#ifeq historyMaxItems -1}}selected{{/ifeq}}>{{res 'setFileHistUnlimited'}}</option>
-    </select>
-    {{#cmp historyMaxItems 0 '>'}}
-        <label for="settings__file-hist-len">{{res 'setFileHistLen'}}:</label>
-        <input type="text" pattern="\d+" required class="settings__input input-base" id="settings__file-hist-len" value="{{historyMaxItems}}" maxlength="6" />
-    {{/cmp}}
-    <label for="settings__file-hist-size">{{res 'setFileHistSize'}}:</label>
-    <input type="text" pattern="\d+" required class="settings__input input-base" id="settings__file-hist-size" value="{{historyMaxSize}}" maxlength="3" />
+    <section class="settings__section" id="history">
+        <h2>{{Res 'history'}}</h2>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base" id="settings__file-trash" {{#if recycleBinEnabled}}checked{{/if}} />
+            <label for="settings__file-trash">{{res 'setFileEnableTrash'}}</label>
+        </div>
+        <div class="settings__field">
+            <label for="settings__file-hist-type">{{res 'setFileHistMode'}}</label>
+            <div class="settings__field-controls">
+                <select class="settings__select input-base" id="settings__file-hist-type">
+                    <option value="1" {{#cmp historyMaxItems 0 '>'}}selected{{/cmp}}>{{res 'setFileHistLimited'}}</option>
+                    <option value="0" {{#ifeq historyMaxItems 0}}selected{{/ifeq}}>{{res 'setFileHistDisabled'}}</option>
+                    <option value="-1" {{#ifeq historyMaxItems -1}}selected{{/ifeq}}>{{res 'setFileHistUnlimited'}}</option>
+                </select>
+            </div>
+        </div>
+        {{#cmp historyMaxItems 0 '>'}}
+            <div class="settings__field">
+                <label for="settings__file-hist-len">{{res 'setFileHistLen'}}:</label>
+                <input type="text" pattern="\d+" required class="settings__input input-base" id="settings__file-hist-len" value="{{historyMaxItems}}" maxlength="6" />
+            </div>
+        {{/cmp}}
+        <div class="settings__field">
+            <label for="settings__file-hist-size">{{res 'setFileHistSize'}}:</label>
+            <input type="text" pattern="\d+" required class="settings__input input-base" id="settings__file-hist-size" value="{{historyMaxSize}}" maxlength="3" />
+        </div>
+    </section>
 
-    <h2>{{res 'advanced'}}</h2>
-    <label for="settings__file-format-version">{{res 'setFileFormatVersion'}}</label>
-    <select class="settings__select input-base" id="settings__file-format-version">
-        <option value="3" {{#ifeq formatVersion 3}}selected{{/ifeq}}>KDBX 3</option>
-        <option value="4" {{#ifeq formatVersion 4}}selected{{/ifeq}}>KDBX 4</option>
-    </select>
-    <label for="settings__file-kdf">{{res 'setFileKdfParams'}}</label>
-    <select class="settings__select input-base" id="settings__file-kdf" {{#ifneq formatVersion 4}}disabled{{/ifneq}}>
-        <option value="Aes" {{#ifeq kdfName 'AES'}}selected{{/ifeq}}>AES</option>
-        {{#ifeq formatVersion 4}}<option value="Argon2d" {{#ifeq kdfName 'Argon2d'}}selected{{/ifeq}}>Argon2d</option>{{/ifeq}}
-        {{#ifeq formatVersion 4}}<option value="Argon2id" {{#ifeq kdfName 'Argon2id'}}selected{{/ifeq}}>Argon2id</option>{{/ifeq}}
-    </select>
-    {{#if keyEncryptionRounds}}
-    <label for="settings__file-key-rounds">{{res 'setFileRounds'}}:</label>
-    <input type="text" pattern="\d+" required class="settings__input input-base" id="settings__file-key-rounds" value="{{keyEncryptionRounds}}" maxlength="10" />
-    {{else if kdfParameters}}
-        {{#ifeq kdfName 'Aes'}}
-            <div>
-                <label for="settings__file-kdf-rounds">{{res 'setFileRounds'}}:</label>
-                <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
-                       id="settings__file-kdf-rounds" data-field="rounds" value="{{kdfParameters.rounds}}" maxlength="10" />
+    <section class="settings__section" id="advanced">
+        <h2>{{res 'advanced'}}</h2>
+        <div class="settings__field">
+            <label for="settings__file-format-version">{{res 'setFileFormatVersion'}}</label>
+            <div class="settings__field-controls">
+                <select class="settings__select input-base" id="settings__file-format-version">
+                    <option value="3" {{#ifeq formatVersion 3}}selected{{/ifeq}}>KDBX 3</option>
+                    <option value="4" {{#ifeq formatVersion 4}}selected{{/ifeq}}>KDBX 4</option>
+                </select>
             </div>
-        {{/ifeq}}
-        {{#if isArgon2Kdf}}
-            <div class="settings__row">
-                <div class="settings__col-small">
-                    <label class="settings__col-small-label" for="settings__file-kdf-iter">{{res 'setFileKdfParamsIter'}}:</label>
-                    <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
-                           data-field="iterations" id="settings__file-kdf-iter" value="{{kdfParameters.iterations}}" maxlength="10" />
-                </div>
-                <div class="settings__col-small">
-                    <label class="settings__col-small-label" for="settings__file-kdf-mem">{{res 'setFileKdfParamsMem'}}:</label>
-                    <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
-                           data-field="memory" data-mul="1024" id="settings__file-kdf-mem" value="{{kdfParameters.memory}}" maxlength="10" />
-                </div>
-                <div class="settings__col-small">
-                    <label class="settings__col-small-label" for="settings__file-kdf-par">{{res 'setFileKdfParamsPar'}}:</label>
-                    <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
-                           data-field="parallelism" id="settings__file-kdf-par" value="{{kdfParameters.parallelism}}" maxlength="2" />
-                </div>
+        </div>
+
+        <div class="settings__field">
+            <label for="settings__file-kdf">{{res 'setFileKdfParams'}}</label>
+            <div class="settings__field-controls">
+                <select class="settings__select input-base" id="settings__file-kdf" {{#ifneq formatVersion 4}}disabled{{/ifneq}}>
+                    <option value="Aes" {{#ifeq kdfName 'AES'}}selected{{/ifeq}}>AES</option>
+                    {{#ifeq formatVersion 4}}<option value="Argon2d" {{#ifeq kdfName 'Argon2d'}}selected{{/ifeq}}>Argon2d</option>{{/ifeq}}
+                    {{#ifeq formatVersion 4}}<option value="Argon2id" {{#ifeq kdfName 'Argon2id'}}selected{{/ifeq}}>Argon2id</option>{{/ifeq}}
+                </select>
             </div>
+        </div>
+
+        {{#if keyEncryptionRounds}}
+            <div class="settings__field">
+                <label for="settings__file-key-rounds">{{res 'setFileRounds'}}:</label>
+                <input type="text" pattern="\d+" required class="settings__input input-base" id="settings__file-key-rounds" value="{{keyEncryptionRounds}}" maxlength="10" />
+            </div>
+        {{else if kdfParameters}}
+            {{#ifeq kdfName 'Aes'}}
+                <div class="settings__field">
+                    <label for="settings__file-kdf-rounds">{{res 'setFileRounds'}}:</label>
+                    <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
+                           id="settings__file-kdf-rounds" data-field="rounds" value="{{kdfParameters.rounds}}" maxlength="10" />
+                </div>
+            {{/ifeq}}
+            {{#if isArgon2Kdf}}
+                <div class="settings__row settings__row--kdf">
+                    <div class="settings__col-small">
+                        <label class="settings__col-small-label" for="settings__file-kdf-iter">{{res 'setFileKdfParamsIter'}}:</label>
+                        <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
+                               data-field="iterations" id="settings__file-kdf-iter" value="{{kdfParameters.iterations}}" maxlength="10" />
+                    </div>
+                    <div class="settings__col-small">
+                        <label class="settings__col-small-label" for="settings__file-kdf-mem">{{res 'setFileKdfParamsMem'}}:</label>
+                        <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
+                               data-field="memory" data-mul="1024" id="settings__file-kdf-mem" value="{{kdfParameters.memory}}" maxlength="10" />
+                    </div>
+                    <div class="settings__col-small">
+                        <label class="settings__col-small-label" for="settings__file-kdf-par">{{res 'setFileKdfParamsPar'}}:</label>
+                        <input type="text" pattern="\d+" required class="settings__input input-base settings__input-kdf"
+                               data-field="parallelism" id="settings__file-kdf-par" value="{{kdfParameters.parallelism}}" maxlength="2" />
+                    </div>
+                </div>
+            {{/if}}
         {{/if}}
-    {{/if}}
 
-    <label for="settings__file-key-change-force">{{res 'setFileKeyChangeForce'}}:</label>
-    <input type="text" pattern="\d*" class="settings__input input-base" id="settings__file-key-change-force" value="{{keyChangeForce}}" maxlength="6" />
+        <div class="settings__field">
+            <label for="settings__file-key-change-force">{{res 'setFileKeyChangeForce'}}:</label>
+            <input type="text" pattern="\d*" class="settings__input input-base" id="settings__file-key-change-force" value="{{keyChangeForce}}" maxlength="6" />
+        </div>
+    </section>
 </div>

--- a/app/templates/settings/settings-general.hbs
+++ b/app/templates/settings/settings-general.hbs
@@ -1,349 +1,346 @@
-<div class="settings__content">
-    <h1 id="top"><i class="fa fa-cog settings__head-icon"></i> {{res 'setGenTitle'}}</h1>
+<div class="settings__content settings__content--cards settings__content--general">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title" id="top"><i class="fa fa-cog settings__head-icon"></i> {{res 'setGenTitle'}}</h1>
+    </section>
 
     {{#if updateWaitingReload}}
-    <h2 class="action-color">{{res 'setGenUpdate'}}</h2>
-    <div>{{res 'setGenNewVersion'}}. <a href="{{releaseNotesLink}}" target="_blank">{{res 'setGenReleaseNotes'}}</a></div>
-    <div class="settings__general-update-buttons">
-        <button class="settings__general-restart-btn">{{res 'setGenReloadToUpdate'}}</button>
-    </div>
+    <section class="settings__section">
+        <h2 class="action-color">{{res 'setGenUpdate'}}</h2>
+        <p class="settings__meta">{{res 'setGenNewVersion'}}. <a href="{{releaseNotesLink}}" target="_blank">{{res 'setGenReleaseNotes'}}</a></p>
+        <div class="settings__general-update-buttons">
+            <button class="settings__general-restart-btn">{{res 'setGenReloadToUpdate'}}</button>
+        </div>
+    </section>
     {{else if updateManual}}
-    <h2 class="action-color">{{res 'setGenUpdate'}}</h2>
-    <div>{{res 'setGenUpdateManual'}}</div>
-    <div class="settings__general-update-buttons">
-        <button class="settings__general-download-update-btn">{{res 'setGenDownloadUpdate'}}</button>
-    </div>
-    {{/if}}
-    {{#if showUpdateBlock}}
-    <h2>{{res 'setGenUpdate'}}</h2>
-    <div>
-        <select class="settings__general-auto-update settings__select input-base">
-            <option value="install" {{#ifeq autoUpdate 'install'}}selected{{/ifeq}}>{{res 'setGenUpdateAuto'}}</option>
-            <option value="check" {{#ifeq autoUpdate 'check'}}selected{{/ifeq}}>{{res 'setGenUpdateCheck'}}</option>
-            <option value="" {{#unless autoUpdate}}selected{{/unless}}>{{res 'setGenNoUpdate'}}</option>
-        </select>
-        <div>{{updateInfo}}</div>
-        <a href="{{releaseNotesLink}}" target="_blank">{{res 'setGenReleaseNotes'}}</a>
-    </div>
-    <div class="settings__general-update-buttons">
-        {{#if updateInProgress}}
-        <button class="settings__general-update-btn btn-silent" disabled>{{res 'setGenUpdateChecking'}}</button>
-        {{else}}
-        <button class="settings__general-update-btn btn-silent">{{res 'setGenCheckUpdate'}}</button>
-        {{/if}}
-        {{#if updateReady}}<button class="settings__general-restart-btn">{{res 'setGenRestartToUpdate'}}</button>{{/if}}
-        {{#if updateFound}}<button class="settings__general-update-found-btn">{{res 'setGenDownloadAndRestart'}}</button>{{/if}}
-    </div>
+    <section class="settings__section">
+        <h2 class="action-color">{{res 'setGenUpdate'}}</h2>
+        <p class="settings__meta">{{res 'setGenUpdateManual'}}</p>
+        <div class="settings__general-update-buttons">
+            <button class="settings__general-download-update-btn">{{res 'setGenDownloadUpdate'}}</button>
+        </div>
+    </section>
     {{/if}}
 
-    <h2 id="appearance">{{res 'setGenAppearance'}}</h2>
-    {{#if locales}}
-    <div>
-        <label for="settings__general-locale">{{res 'setGenLocale'}}:</label>
-        <select class="settings__general-locale settings__select input-base" id="settings__general-locale">
-            {{#each locales as |name key|}}
-                <option value="{{key}}" {{#ifeq key ../activeLocale}}selected{{/ifeq}}>{{name}}</option>
-            {{/each}}
-            <option value="...">({{res 'setGenLocOther'}})</option>
-        </select>
-    </div>
+    {{#if showUpdateBlock}}
+    <section class="settings__section">
+        <h2>{{res 'setGenUpdate'}}</h2>
+        <div class="settings__field">
+            <label for="settings__general-auto-update">{{res 'setGenUpdate'}}:</label>
+            <select id="settings__general-auto-update" class="settings__general-auto-update settings__select input-base">
+                <option value="install" {{#ifeq autoUpdate 'install'}}selected{{/ifeq}}>{{res 'setGenUpdateAuto'}}</option>
+                <option value="check" {{#ifeq autoUpdate 'check'}}selected{{/ifeq}}>{{res 'setGenUpdateCheck'}}</option>
+                <option value="" {{#unless autoUpdate}}selected{{/unless}}>{{res 'setGenNoUpdate'}}</option>
+            </select>
+        </div>
+        <div class="settings__meta">{{updateInfo}}</div>
+        <a href="{{releaseNotesLink}}" target="_blank">{{res 'setGenReleaseNotes'}}</a>
+        <div class="settings__general-update-buttons">
+            {{#if updateInProgress}}
+            <button class="settings__general-update-btn btn-silent" disabled>{{res 'setGenUpdateChecking'}}</button>
+            {{else}}
+            <button class="settings__general-update-btn btn-silent">{{res 'setGenCheckUpdate'}}</button>
+            {{/if}}
+            {{#if updateReady}}<button class="settings__general-restart-btn">{{res 'setGenRestartToUpdate'}}</button>{{/if}}
+            {{#if updateFound}}<button class="settings__general-update-found-btn">{{res 'setGenDownloadAndRestart'}}</button>{{/if}}
+        </div>
+    </section>
     {{/if}}
-    <div>
-        <label>{{res 'setGenTheme'}}:</label>
-        <div class="settings__general-themes">
-            {{#each themes as |name key|}}
-                <div class="th-{{key}} settings__general-theme
-                    {{~#ifeq key ../activeTheme}} settings__general-theme--selected{{/ifeq~}}"
-                     data-theme="{{key}}"
-                >
-                    <div class="settings__general-theme-name">{{name}}</div>
-                    <button class="settings__general-theme-button"><i class="fa fa-ellipsis-h"></i></button>
+
+    <section class="settings__section" id="appearance">
+        <h2>{{res 'setGenAppearance'}}</h2>
+        {{#if locales}}
+        <div class="settings__field">
+            <label for="settings__general-locale">{{res 'setGenLocale'}}:</label>
+            <select class="settings__general-locale settings__select input-base" id="settings__general-locale">
+                {{#each locales as |name key|}}
+                    <option value="{{key}}" {{#ifeq key ../activeLocale}}selected{{/ifeq}}>{{name}}</option>
+                {{/each}}
+                <option value="...">({{res 'setGenLocOther'}})</option>
+            </select>
+        </div>
+        {{/if}}
+        <div class="settings__field settings__field--stack">
+            <label>{{res 'setGenTheme'}}:</label>
+            <div class="settings__general-themes">
+                {{#each themes as |name key|}}
+                    <div class="th-{{key}} settings__general-theme
+                        {{~#ifeq key ../activeTheme}} settings__general-theme--selected{{/ifeq~}}"
+                        data-theme="{{key}}"
+                    >
+                        <div class="settings__general-theme-name">{{name}}</div>
+                        <button class="settings__general-theme-button"><i class="fa fa-ellipsis-h"></i></button>
+                    </div>
+                {{/each}}
+                <div class="settings__general-theme settings__general-theme-plugins" data-theme="...">
+                    <div class="settings__general-theme-plugins-name">{{res 'setGenMoreThemes'}}</div>
+                    <i class="settings__general-theme-plugins-icon fa fa-puzzle-piece"></i>
                 </div>
-            {{/each}}
-            <div class="settings__general-theme settings__general-theme-plugins" data-theme="...">
-                <div class="settings__general-theme-plugins-name">{{res 'setGenMoreThemes'}}</div>
-                <i class="settings__general-theme-plugins-icon fa fa-puzzle-piece"></i>
             </div>
         </div>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-auto-switch-theme" id="settings__general-auto-switch-theme" {{#if autoSwitchTheme}}checked{{/if}} />
-        <label for="settings__general-auto-switch-theme">{{res 'setGenAutoSwitchTheme'}}</label>
-    </div>
-    <div>
-        <label for="settings__general-font-size">{{res 'setGenFontSize'}}:</label>
-        <select class="settings__general-font-size settings__select input-base" id="settings__general-font-size">
-            <option value="0" {{#ifeq fontSize 0}}selected{{/ifeq}}>{{res 'setGenFontSizeNormal'}}</option>
-            <option value="1" {{#ifeq fontSize 1}}selected{{/ifeq}}>{{res 'setGenFontSizeLarge'}}</option>
-            <option value="2" {{#ifeq fontSize 2}}selected{{/ifeq}}>{{res 'setGenFontSizeLargest'}}</option>
-        </select>
-    </div>
-    {{#if supportsTitleBarStyles}}
-    <div>
-        <label for="settings__general-titlebar-style">{{res 'setGenTitlebarStyle'}}:</label>
-        <select class="settings__general-titlebar-style settings__select input-base" id="settings__general-titlebar-style">
-            <option value="default" {{#ifeq titlebarStyle 'default'}}selected{{/ifeq}}>{{res 'setGenTitlebarStyleDefault'}}</option>
-            <option value="hidden" {{#ifeq titlebarStyle 'hidden'}}selected{{/ifeq}}>{{res 'setGenTitlebarStyleHidden'}}</option>
-            {{#if supportsCustomTitleBarAndDraggableWindow}}
-                <option value="hidden-inset" {{#ifeq titlebarStyle 'hidden-inset'}}selected{{/ifeq}}>{{res 'setGenTitlebarStyleHiddenInset'}}</option>
-            {{/if}}
-        </select>
-    </div>
-    {{/if}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-expand" id="settings__general-expand" {{#if expandGroups}}checked{{/if}} />
-        <label for="settings__general-expand">{{res 'setGenShowSubgroups'}}</label>
-    </div>
-    {{#if canSetTableView}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-table-view" id="settings__general-table-view" {{#if tableView}}checked{{/if}} />
-        <label for="settings__general-table-view">{{res 'setGenTableView'}}</label>
-    </div>
-    {{/if}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-colorful-icons" id="settings__general-colorful-icons" {{#if colorfulIcons}}checked{{/if}} />
-        <label for="settings__general-colorful-icons">{{res 'setGenColorfulIcons'}}</label>
-    </div>
-
-    <h2 id="function">{{res 'setGenFunction'}}</h2>
-    {{#if canAutoSaveOnClose}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-auto-save" id="settings__general-auto-save"
-            {{#if autoSave}}checked{{/if}} />
-        <label for="settings__general-auto-save">{{res 'setGenAutoSyncOnClose'}}</label>
-    </div>
-    {{/if}}
-    <div>
-        <label for="settings__general-auto-save-interval">{{res 'setGenAutoSyncTimer'}}:</label>
-        <select class="settings__select input-base settings__general-auto-save-interval"
-                id="settings__general-auto-save-interval">
-            <option value="0" {{#ifeq autoSaveInterval 0}}selected{{/ifeq}}>{{res 'setGenAutoSyncTimerOff'}}</option>
-            <option value="-1" {{#ifeq autoSaveInterval -1}}selected{{/ifeq}}>{{res 'setGenAutoSyncTimerOnChange'}}</option>
-            <option value="1" {{#ifeq autoSaveInterval 1}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}
-                1{{/res}}</option>
-            <option value="5" {{#ifeq autoSaveInterval 5}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}
-                5{{/res}}</option>
-            <option value="15" {{#ifeq autoSaveInterval 15}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}
-                15{{/res}}</option>
-            <option value="30" {{#ifeq autoSaveInterval 30}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}
-                30{{/res}}</option>
-            <option value="60" {{#ifeq autoSaveInterval 60}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}
-                60{{/res}}</option>
-        </select>
-    </div>
-    <div>
-        <label for="settings__general-remember-key-files">{{res 'setGenRememberKeyFiles'}}:</label>
-        <select class="settings__general-remember-key-files settings__select input-base" id="settings__general-remember-key-files">
-            <option value="" {{#unless rememberKeyFiles}}selected{{/unless}}>{{res 'setGenNoRememberKeyFiles'}}</option>
-            <option value="data" {{#ifeq rememberKeyFiles 'data'}}selected{{/ifeq}}>{{res 'setGenRememberKeyFilesData'}}</option>
-            {{#if supportFiles}}<option value="path" {{#ifeq rememberKeyFiles 'path'}}selected{{/ifeq}}>{{res 'setGenRememberKeyFilesPath'}}</option>{{/if}}
-        </select>
-    </div>
-    {{#if canClearClipboard}}
-    <div>
-        <label for="settings__general-clipboard">{{res 'setGenClearClip'}}:</label>
-        <select class="settings__general-clipboard settings__select input-base" id="settings__general-clipboard">
-            <option value="0" {{#unless clipboardSeconds}}selected{{/unless}}>{{res 'setGenNoClear'}}</option>
-            <option value="5" {{#ifeq clipboardSeconds 5}}selected{{/ifeq}}>{{#res 'setGenClearSeconds'}}5{{/res}}</option>
-            <option value="10" {{#ifeq clipboardSeconds 10}}selected{{/ifeq}}>{{#res 'setGenClearSeconds'}}10{{/res}}</option>
-            <option value="15" {{#ifeq clipboardSeconds 15}}selected{{/ifeq}}>{{#res 'setGenClearSeconds'}}15{{/res}}</option>
-            <option value="60" {{#ifeq clipboardSeconds 60}}selected{{/ifeq}}>{{res 'setGenClearMinute'}}</option>
-        </select>
-    </div>
-    {{/if}}
-    {{#if canMinimize}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-minimize" id="settings__general-minimize"
-            {{#if minimizeOnClose}}checked{{/if}} />
-        <label for="settings__general-minimize">{{res 'setGenMinInstead'}}</label>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-minimize-on-field-copy" id="settings__general-minimize-on-field-copy"
-            {{#if minimizeOnFieldCopy}}checked{{/if}} />
-        <label for="settings__general-minimize-on-field-copy">{{res 'setGenMinOnFieldCopy'}}</label>
-    </div>
-    {{/if}}
-    {{#if canAutoType}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-direct-autotype"
-            id="settings__general-direct-autotype" {{#if directAutotype}}checked{{/if}} />
-        <label for="settings__general-direct-autotype">{{res 'setGenDirectAutotype'}}</label>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-autotype-title-filter"
-               id="settings__general-autotype-title-filter" {{#if autoTypeTitleFilterEnabled}}checked{{/if}} />
-        <label for="settings__general-autotype-title-filter">{{res 'setGenAutoTypeTitleFilterEnabled'}}</label>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-field-label-dblclick-autotype"
-               id="settings__general-field-label-dblclick-autotype" {{#if fieldLabelDblClickAutoType}}checked{{/if}} />
-        <label for="settings__general-field-label-dblclick-autotype">{{res 'setGenFieldLabelDblClickAutoType'}}</label>
-    </div>
-    {{/if}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-use-markdown" id="settings__general-use-markdown" {{#if useMarkdown}}checked{{/if}} />
-        <label for="settings__general-use-markdown">{{res 'setGenUseMarkdown'}}</label>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-use-group-icon-for-entries"
-               id="settings__general-use-group-icon-for-entries" {{#if useGroupIconForEntries}}checked{{/if}} />
-        <label for="settings__general-use-group-icon-for-entries">{{res 'setGenUseGroupIconForEntries'}}</label>
-    </div>
-    {{#if hasDeviceOwnerAuth}}
-        <div>
-            <label for="settings__general-device-owner-auth">{{res 'setGenTouchId'}}:</label>
-            <select class="settings__general-device-owner-auth settings__select input-base" id="settings__general-device-owner-auth">
-                <option value="" {{#unless deviceOwnerAuth}}selected{{/unless}}>{{res 'setGenTouchIdDisabled'}}</option>
-                <option value="memory" {{#ifeq deviceOwnerAuth 'memory'}}selected{{/ifeq}}>{{res 'setGenTouchIdMemory'}}</option>
-                <option value="file" {{#ifeq deviceOwnerAuth 'file'}}selected{{/ifeq}}>{{res 'setGenTouchIdFile'}}</option>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-auto-switch-theme" id="settings__general-auto-switch-theme" {{#if autoSwitchTheme}}checked{{/if}} />
+            <label for="settings__general-auto-switch-theme">{{res 'setGenAutoSwitchTheme'}}</label>
+        </div>
+        <div class="settings__field">
+            <label for="settings__general-font-size">{{res 'setGenFontSize'}}:</label>
+            <select class="settings__general-font-size settings__select input-base" id="settings__general-font-size">
+                <option value="0" {{#ifeq fontSize 0}}selected{{/ifeq}}>{{res 'setGenFontSizeNormal'}}</option>
+                <option value="1" {{#ifeq fontSize 1}}selected{{/ifeq}}>{{res 'setGenFontSizeLarge'}}</option>
+                <option value="2" {{#ifeq fontSize 2}}selected{{/ifeq}}>{{res 'setGenFontSizeLargest'}}</option>
             </select>
         </div>
-        {{#if deviceOwnerAuth}}
-            <label for="settings__general-device-owner-auth-timeout">{{res 'setGenTouchIdPass'}}:</label>
-            <select class="settings__general-device-owner-auth-timeout settings__select input-base" id="settings__general-device-owner-auth-timeout">
-                <option value="1" {{#ifeq deviceOwnerAuthTimeout 1}}selected{{/ifeq}}>{{Res 'oneMinute'}}</option>
-                <option value="5" {{#ifeq deviceOwnerAuthTimeout 5}}selected{{/ifeq}}>{{#Res 'minutes'}}5{{/Res}}</option>
-                <option value="30" {{#ifeq deviceOwnerAuthTimeout 30}}selected{{/ifeq}}>{{#Res 'minutes'}}30{{/Res}}</option>
-                <option value="60" {{#ifeq deviceOwnerAuthTimeout 60}}selected{{/ifeq}}>{{Res 'oneHour'}}</option>
-                <option value="120" {{#ifeq deviceOwnerAuthTimeout 120}}selected{{/ifeq}}>{{#Res 'hours'}}2{{/Res}}</option>
-                <option value="480" {{#ifeq deviceOwnerAuthTimeout 480}}selected{{/ifeq}}>{{#Res 'hours'}}8{{/Res}}</option>
-                <option value="1440" {{#ifeq deviceOwnerAuthTimeout 1440}}selected{{/ifeq}}>{{Res 'oneDay'}}</option>
-                <option value="10080" {{#ifeq deviceOwnerAuthTimeout 10080}}selected{{/ifeq}}>{{Res 'oneWeek'}}</option>
-                {{#ifeq deviceOwnerAuth 'file'}}
-                    <option value="43200" {{#ifeq deviceOwnerAuthTimeout 43200}}selected{{/ifeq}}>{{Res 'oneMonth'}}</option>
-                    <option value="525600" {{#ifeq deviceOwnerAuthTimeout 525600}}selected{{/ifeq}}>{{Res 'oneYear'}}</option>
-                {{/ifeq}}
+        {{#if supportsTitleBarStyles}}
+        <div class="settings__field">
+            <label for="settings__general-titlebar-style">{{res 'setGenTitlebarStyle'}}:</label>
+            <select class="settings__general-titlebar-style settings__select input-base" id="settings__general-titlebar-style">
+                <option value="default" {{#ifeq titlebarStyle 'default'}}selected{{/ifeq}}>{{res 'setGenTitlebarStyleDefault'}}</option>
+                <option value="hidden" {{#ifeq titlebarStyle 'hidden'}}selected{{/ifeq}}>{{res 'setGenTitlebarStyleHidden'}}</option>
+                {{#if supportsCustomTitleBarAndDraggableWindow}}
+                    <option value="hidden-inset" {{#ifeq titlebarStyle 'hidden-inset'}}selected{{/ifeq}}>{{res 'setGenTitlebarStyleHiddenInset'}}</option>
+                {{/if}}
             </select>
+        </div>
         {{/if}}
-    {{/if}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-expand" id="settings__general-expand" {{#if expandGroups}}checked{{/if}} />
+            <label for="settings__general-expand">{{res 'setGenShowSubgroups'}}</label>
+        </div>
+        {{#if canSetTableView}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-table-view" id="settings__general-table-view" {{#if tableView}}checked{{/if}} />
+            <label for="settings__general-table-view">{{res 'setGenTableView'}}</label>
+        </div>
+        {{/if}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-colorful-icons" id="settings__general-colorful-icons" {{#if colorfulIcons}}checked{{/if}} />
+            <label for="settings__general-colorful-icons">{{res 'setGenColorfulIcons'}}</label>
+        </div>
+    </section>
 
-    <h2 id="audit">{{res 'setGenAudit'}}</h2>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-audit-passwords"
-               id="settings__general-audit-passwords" {{#if auditPasswords}}checked{{/if}} />
-        <label for="settings__general-audit-passwords">{{res 'setGenAuditPasswords'}}</label>
-    </div>
+    <section class="settings__section" id="function">
+        <h2>{{res 'setGenFunction'}}</h2>
+        {{#if canAutoSaveOnClose}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-auto-save" id="settings__general-auto-save" {{#if autoSave}}checked{{/if}} />
+            <label for="settings__general-auto-save">{{res 'setGenAutoSyncOnClose'}}</label>
+        </div>
+        {{/if}}
+        <div class="settings__field">
+            <label for="settings__general-auto-save-interval">{{res 'setGenAutoSyncTimer'}}:</label>
+            <select class="settings__select input-base settings__general-auto-save-interval" id="settings__general-auto-save-interval">
+                <option value="0" {{#ifeq autoSaveInterval 0}}selected{{/ifeq}}>{{res 'setGenAutoSyncTimerOff'}}</option>
+                <option value="-1" {{#ifeq autoSaveInterval -1}}selected{{/ifeq}}>{{res 'setGenAutoSyncTimerOnChange'}}</option>
+                <option value="1" {{#ifeq autoSaveInterval 1}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}1{{/res}}</option>
+                <option value="5" {{#ifeq autoSaveInterval 5}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}5{{/res}}</option>
+                <option value="15" {{#ifeq autoSaveInterval 15}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}15{{/res}}</option>
+                <option value="30" {{#ifeq autoSaveInterval 30}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}30{{/res}}</option>
+                <option value="60" {{#ifeq autoSaveInterval 60}}selected{{/ifeq}}>{{#res 'setGenAutoSyncTimerInterval'}}60{{/res}}</option>
+            </select>
+        </div>
+        <div class="settings__field">
+            <label for="settings__general-remember-key-files">{{res 'setGenRememberKeyFiles'}}:</label>
+            <select class="settings__general-remember-key-files settings__select input-base" id="settings__general-remember-key-files">
+                <option value="" {{#unless rememberKeyFiles}}selected{{/unless}}>{{res 'setGenNoRememberKeyFiles'}}</option>
+                <option value="data" {{#ifeq rememberKeyFiles 'data'}}selected{{/ifeq}}>{{res 'setGenRememberKeyFilesData'}}</option>
+                {{#if supportFiles}}<option value="path" {{#ifeq rememberKeyFiles 'path'}}selected{{/ifeq}}>{{res 'setGenRememberKeyFilesPath'}}</option>{{/if}}
+            </select>
+        </div>
+        {{#if canClearClipboard}}
+        <div class="settings__field">
+            <label for="settings__general-clipboard">{{res 'setGenClearClip'}}:</label>
+            <select class="settings__general-clipboard settings__select input-base" id="settings__general-clipboard">
+                <option value="0" {{#unless clipboardSeconds}}selected{{/unless}}>{{res 'setGenNoClear'}}</option>
+                <option value="5" {{#ifeq clipboardSeconds 5}}selected{{/ifeq}}>{{#res 'setGenClearSeconds'}}5{{/res}}</option>
+                <option value="10" {{#ifeq clipboardSeconds 10}}selected{{/ifeq}}>{{#res 'setGenClearSeconds'}}10{{/res}}</option>
+                <option value="15" {{#ifeq clipboardSeconds 15}}selected{{/ifeq}}>{{#res 'setGenClearSeconds'}}15{{/res}}</option>
+                <option value="60" {{#ifeq clipboardSeconds 60}}selected{{/ifeq}}>{{res 'setGenClearMinute'}}</option>
+            </select>
+        </div>
+        {{/if}}
+        {{#if canMinimize}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-minimize" id="settings__general-minimize" {{#if minimizeOnClose}}checked{{/if}} />
+            <label for="settings__general-minimize">{{res 'setGenMinInstead'}}</label>
+        </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-minimize-on-field-copy" id="settings__general-minimize-on-field-copy" {{#if minimizeOnFieldCopy}}checked{{/if}} />
+            <label for="settings__general-minimize-on-field-copy">{{res 'setGenMinOnFieldCopy'}}</label>
+        </div>
+        {{/if}}
+        {{#if canAutoType}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-direct-autotype" id="settings__general-direct-autotype" {{#if directAutotype}}checked{{/if}} />
+            <label for="settings__general-direct-autotype">{{res 'setGenDirectAutotype'}}</label>
+        </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-autotype-title-filter" id="settings__general-autotype-title-filter" {{#if autoTypeTitleFilterEnabled}}checked{{/if}} />
+            <label for="settings__general-autotype-title-filter">{{res 'setGenAutoTypeTitleFilterEnabled'}}</label>
+        </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-field-label-dblclick-autotype" id="settings__general-field-label-dblclick-autotype" {{#if fieldLabelDblClickAutoType}}checked{{/if}} />
+            <label for="settings__general-field-label-dblclick-autotype">{{res 'setGenFieldLabelDblClickAutoType'}}</label>
+        </div>
+        {{/if}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-use-markdown" id="settings__general-use-markdown" {{#if useMarkdown}}checked{{/if}} />
+            <label for="settings__general-use-markdown">{{res 'setGenUseMarkdown'}}</label>
+        </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-use-group-icon-for-entries" id="settings__general-use-group-icon-for-entries" {{#if useGroupIconForEntries}}checked{{/if}} />
+            <label for="settings__general-use-group-icon-for-entries">{{res 'setGenUseGroupIconForEntries'}}</label>
+        </div>
+        {{#if hasDeviceOwnerAuth}}
+            <div class="settings__field">
+                <label for="settings__general-device-owner-auth">{{res 'setGenTouchId'}}:</label>
+                <select class="settings__general-device-owner-auth settings__select input-base" id="settings__general-device-owner-auth">
+                    <option value="" {{#unless deviceOwnerAuth}}selected{{/unless}}>{{res 'setGenTouchIdDisabled'}}</option>
+                    <option value="memory" {{#ifeq deviceOwnerAuth 'memory'}}selected{{/ifeq}}>{{res 'setGenTouchIdMemory'}}</option>
+                    <option value="file" {{#ifeq deviceOwnerAuth 'file'}}selected{{/ifeq}}>{{res 'setGenTouchIdFile'}}</option>
+                </select>
+            </div>
+            {{#if deviceOwnerAuth}}
+                <div class="settings__field">
+                    <label for="settings__general-device-owner-auth-timeout">{{res 'setGenTouchIdPass'}}:</label>
+                    <select class="settings__general-device-owner-auth-timeout settings__select input-base" id="settings__general-device-owner-auth-timeout">
+                        <option value="1" {{#ifeq deviceOwnerAuthTimeout 1}}selected{{/ifeq}}>{{Res 'oneMinute'}}</option>
+                        <option value="5" {{#ifeq deviceOwnerAuthTimeout 5}}selected{{/ifeq}}>{{#Res 'minutes'}}5{{/Res}}</option>
+                        <option value="30" {{#ifeq deviceOwnerAuthTimeout 30}}selected{{/ifeq}}>{{#Res 'minutes'}}30{{/Res}}</option>
+                        <option value="60" {{#ifeq deviceOwnerAuthTimeout 60}}selected{{/ifeq}}>{{Res 'oneHour'}}</option>
+                        <option value="120" {{#ifeq deviceOwnerAuthTimeout 120}}selected{{/ifeq}}>{{#Res 'hours'}}2{{/Res}}</option>
+                        <option value="480" {{#ifeq deviceOwnerAuthTimeout 480}}selected{{/ifeq}}>{{#Res 'hours'}}8{{/Res}}</option>
+                        <option value="1440" {{#ifeq deviceOwnerAuthTimeout 1440}}selected{{/ifeq}}>{{Res 'oneDay'}}</option>
+                        <option value="10080" {{#ifeq deviceOwnerAuthTimeout 10080}}selected{{/ifeq}}>{{Res 'oneWeek'}}</option>
+                        {{#ifeq deviceOwnerAuth 'file'}}
+                            <option value="43200" {{#ifeq deviceOwnerAuthTimeout 43200}}selected{{/ifeq}}>{{Res 'oneMonth'}}</option>
+                            <option value="525600" {{#ifeq deviceOwnerAuthTimeout 525600}}selected{{/ifeq}}>{{Res 'oneYear'}}</option>
+                        {{/ifeq}}
+                    </select>
+                </div>
+            {{/if}}
+        {{/if}}
+    </section>
 
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-audit-password-entropy"
-               id="settings__general-audit-password-entropy" {{#if auditPasswordEntropy}}checked{{/if}} />
-        <label for="settings__general-audit-password-entropy">{{res 'setGenAuditPasswordEntropy'}}</label>
-    </div>
+    <section class="settings__section" id="audit">
+        <h2>{{res 'setGenAudit'}}</h2>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-audit-passwords" id="settings__general-audit-passwords" {{#if auditPasswords}}checked{{/if}} />
+            <label for="settings__general-audit-passwords">{{res 'setGenAuditPasswords'}}</label>
+        </div>
 
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-exclude-pins-from-audit"
-               id="settings__general-exclude-pins-from-audit" {{#if excludePinsFromAudit}}checked{{/if}} />
-        <label for="settings__general-exclude-pins-from-audit">{{res 'setGenExcludePinsFromAudit'}}</label>
-    </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-audit-password-entropy" id="settings__general-audit-password-entropy" {{#if auditPasswordEntropy}}checked{{/if}} />
+            <label for="settings__general-audit-password-entropy">{{res 'setGenAuditPasswordEntropy'}}</label>
+        </div>
 
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-check-passwords-on-hibp"
-               id="settings__general-check-passwords-on-hibp" {{#if checkPasswordsOnHIBP}}checked{{/if}} />
-        <label for="settings__general-check-passwords-on-hibp">
-            {{~#res 'setGenCheckPasswordsOnHIBP'~}}
-                <a href="{{hibpLink}}" rel="noreferrer noopener" target="_blank">Have I Been Pwned</a>
-            {{~/res~}}
-        </label>
-        <i class="fa fa-info-circle info-btn settings__general-toggle-help-hibp"></i>
-        <div class="settings__general-help-hibp hide">
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-exclude-pins-from-audit" id="settings__general-exclude-pins-from-audit" {{#if excludePinsFromAudit}}checked{{/if}} />
+            <label for="settings__general-exclude-pins-from-audit">{{res 'setGenExcludePinsFromAudit'}}</label>
+        </div>
+
+        <div class="settings__check-row settings__check-row--with-help">
+            <input type="checkbox" class="settings__input input-base settings__general-check-passwords-on-hibp" id="settings__general-check-passwords-on-hibp" {{#if checkPasswordsOnHIBP}}checked{{/if}} />
+            <label for="settings__general-check-passwords-on-hibp">
+                {{~#res 'setGenCheckPasswordsOnHIBP'~}}
+                    <a href="{{hibpLink}}" rel="noreferrer noopener" target="_blank">Have I Been Pwned</a>
+                {{~/res~}}
+            </label>
+            <i class="fa fa-info-circle info-btn settings__general-toggle-help-hibp"></i>
+        </div>
+        <div class="settings__general-help-hibp hide settings__meta">
             {{~#res 'setGenHelpHIBP'~}}
                 <a href="{{hibpPrivacyLink}}" rel="noreferrer noopener" target="_blank">{{res 'setGenHelpHIBPLink'}}</a>
             {{~/res~}}
         </div>
-    </div>
 
-    <div>
-        <label for="settings__general-audit-password-age">{{res 'setGenAuditPasswordAge'}}:</label>
-        <select class="settings__select input-base settings__general-audit-password-age"
-                id="settings__general-audit-password-age">
-            <option value="0" {{#ifeq auditPasswordAge 0}}selected{{/ifeq}}>{{res 'setGenAuditPasswordAgeOff'}}</option>
-            <option value="1" {{#ifeq auditPasswordAge 1}}selected{{/ifeq}}>{{res 'setGenAuditPasswordAgeOneYear'}}</option>
-            <option value="2" {{#ifeq auditPasswordAge 2}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}
-                2{{/res}}</option>
-            <option value="3" {{#ifeq auditPasswordAge 3}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}
-                3{{/res}}</option>
-            <option value="5" {{#ifeq auditPasswordAge 5}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}
-                5{{/res}}</option>
-            <option value="10" {{#ifeq auditPasswordAge 10}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}
-                10{{/res}}</option>
-        </select>
-    </div>
-
-    <h2 id="lock">{{res 'setGenLock'}}</h2>
-    <div>
-        <label for="settings__general-idle-minutes">{{res 'setGenLockInactive'}}:</label>
-        <select class="settings__general-idle-minutes settings__select input-base" id="settings__general-idle-minutes">
-            <option value="0" {{#cmp idleMinutes 0 '<='}}selected{{/cmp}}>{{res 'setGenNoAutoLock'}}</option>
-            <option value="5" {{#ifeq idleMinutes 5}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}5{{/res}}</option>
-            <option value="10" {{#ifeq idleMinutes 10}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}10{{/res}}</option>
-            <option value="15" {{#ifeq idleMinutes 15}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}15{{/res}}</option>
-            <option value="30" {{#ifeq idleMinutes 30}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}30{{/res}}</option>
-            <option value="60" {{#ifeq idleMinutes 60}}selected{{/ifeq}}>{{res 'setGenLockHour'}}</option>
-            <option value="180" {{#ifeq idleMinutes 180}}selected{{/ifeq}}>{{#res 'setGenLockHours'}}3{{/res}}</option>
-            <option value="360" {{#ifeq idleMinutes 360}}selected{{/ifeq}}>{{#res 'setGenLockHours'}}6{{/res}}</option>
-            <option value="720" {{#ifeq idleMinutes 720}}selected{{/ifeq}}>{{#res 'setGenLockHours'}}12{{/res}}</option>
-            <option value="1440" {{#ifeq idleMinutes 1440}}selected{{/ifeq}}>{{res 'setGenLockDay'}}</option>
-        </select>
-    </div>
-    {{#if canDetectMinimize}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-lock-on-minimize" id="settings__general-lock-on-minimize"
-               {{#if lockOnMinimize}}checked{{/if}} />
-        <label for="settings__general-lock-on-minimize">{{res 'setGenLockMinimize'}}</label>
-    </div>
-    {{/if}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-lock-on-copy" id="settings__general-lock-on-copy"
-               {{#if lockOnCopy}}checked{{/if}} />
-        <label for="settings__general-lock-on-copy">{{res 'setGenLockCopy'}}</label>
-    </div>
-    {{#if canAutoType}}
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-lock-on-auto-type" id="settings__general-lock-on-auto-type"
-               {{#if lockOnAutoType}}checked{{/if}} />
-        <label for="settings__general-lock-on-auto-type">{{res 'setGenLockAutoType'}}</label>
-    </div>
-    {{/if}}
-    {{#if canDetectOsSleep}}
-        <div>
-            <input type="checkbox" class="settings__input input-base settings__general-lock-on-os-lock" id="settings__general-lock-on-os-lock"
-                   {{#if lockOnOsLock}}checked{{/if}} />
-            <label for="settings__general-lock-on-os-lock">{{res 'setGenLockOrSleep'}}</label>
+        <div class="settings__field">
+            <label for="settings__general-audit-password-age">{{res 'setGenAuditPasswordAge'}}:</label>
+            <select class="settings__select input-base settings__general-audit-password-age" id="settings__general-audit-password-age">
+                <option value="0" {{#ifeq auditPasswordAge 0}}selected{{/ifeq}}>{{res 'setGenAuditPasswordAgeOff'}}</option>
+                <option value="1" {{#ifeq auditPasswordAge 1}}selected{{/ifeq}}>{{res 'setGenAuditPasswordAgeOneYear'}}</option>
+                <option value="2" {{#ifeq auditPasswordAge 2}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}2{{/res}}</option>
+                <option value="3" {{#ifeq auditPasswordAge 3}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}3{{/res}}</option>
+                <option value="5" {{#ifeq auditPasswordAge 5}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}5{{/res}}</option>
+                <option value="10" {{#ifeq auditPasswordAge 10}}selected{{/ifeq}}>{{#res 'setGenAuditPasswordAgeYears'}}10{{/res}}</option>
+            </select>
         </div>
-    {{/if}}
+    </section>
 
-    <h2 id="storage">{{res 'setGenStorage'}}</h2>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-disable-offline-storage" id="settings__general-disable-offline-storage"
-               {{#if disableOfflineStorage}}checked{{/if}} />
-        <label for="settings__general-disable-offline-storage">{{res 'setGenDisableOfflineStorage'}}</label>
-    </div>
-    <div>
-        <input type="checkbox" class="settings__input input-base settings__general-short-lived-storage-token" id="settings__general-short-lived-storage-token"
-               {{#if shortLivedStorageToken}}checked{{/if}} />
-        <label for="settings__general-short-lived-storage-token">{{res 'setGenShortLivedStorageToken'}}</label>
-    </div>
-
-    {{#each storageProviders as |prv|}}
-    <h4 class="settings__general-storage-header"><input
-            type="checkbox" id="settings__general-prv-check-{{prv.name}}" class="settings__general-prv-check"
-            data-storage="{{prv.name}}" {{#if prv.enabled}}checked{{/if}}
-    /><label for="settings__general-prv-check-{{prv.name}}">{{res prv.name}}</label></h4>
-    <div class="settings__general-prv-wrap settings__general-{{prv.name}} {{#ifeq prv.enabled false}}hide{{/ifeq}}"></div>
-    {{#if prv.loggedIn}}<button class="btn-silent settings__general-prv-logout"
-                                data-storage="{{prv.name}}">{{res 'setGenStorageLogout'}}</button>{{/if}}
-    {{/each}}
-
-    <h2 id="advanced">{{res 'advanced'}}</h2>
-    <a class="settings__general-show-advanced">{{res 'setGenShowAdvanced'}}</a>
-    <div class="settings__general-advanced hide">
-        {{#if devTools}}
-            <button class="btn-silent settings__general-dev-tools-link">{{res 'setGenDevTools'}}</button>
-            <button class="btn-silent settings__general-try-beta-link">{{res 'setGenTryBeta'}}</button>
+    <section class="settings__section" id="lock">
+        <h2>{{res 'setGenLock'}}</h2>
+        <div class="settings__field">
+            <label for="settings__general-idle-minutes">{{res 'setGenLockInactive'}}:</label>
+            <select class="settings__general-idle-minutes settings__select input-base" id="settings__general-idle-minutes">
+                <option value="0" {{#cmp idleMinutes 0 '<='}}selected{{/cmp}}>{{res 'setGenNoAutoLock'}}</option>
+                <option value="5" {{#ifeq idleMinutes 5}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}5{{/res}}</option>
+                <option value="10" {{#ifeq idleMinutes 10}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}10{{/res}}</option>
+                <option value="15" {{#ifeq idleMinutes 15}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}15{{/res}}</option>
+                <option value="30" {{#ifeq idleMinutes 30}}selected{{/ifeq}}>{{#res 'setGenLockMinutes'}}30{{/res}}</option>
+                <option value="60" {{#ifeq idleMinutes 60}}selected{{/ifeq}}>{{res 'setGenLockHour'}}</option>
+                <option value="180" {{#ifeq idleMinutes 180}}selected{{/ifeq}}>{{#res 'setGenLockHours'}}3{{/res}}</option>
+                <option value="360" {{#ifeq idleMinutes 360}}selected{{/ifeq}}>{{#res 'setGenLockHours'}}6{{/res}}</option>
+                <option value="720" {{#ifeq idleMinutes 720}}selected{{/ifeq}}>{{#res 'setGenLockHours'}}12{{/res}}</option>
+                <option value="1440" {{#ifeq idleMinutes 1440}}selected{{/ifeq}}>{{res 'setGenLockDay'}}</option>
+            </select>
+        </div>
+        {{#if canDetectMinimize}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-lock-on-minimize" id="settings__general-lock-on-minimize" {{#if lockOnMinimize}}checked{{/if}} />
+            <label for="settings__general-lock-on-minimize">{{res 'setGenLockMinimize'}}</label>
+        </div>
         {{/if}}
-        {{#if showReloadApp}}
-            <button class="btn-silent settings__general-reload-app-link">{{res 'setGenReloadApp'}}</button>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-lock-on-copy" id="settings__general-lock-on-copy" {{#if lockOnCopy}}checked{{/if}} />
+            <label for="settings__general-lock-on-copy">{{res 'setGenLockCopy'}}</label>
+        </div>
+        {{#if canAutoType}}
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-lock-on-auto-type" id="settings__general-lock-on-auto-type" {{#if lockOnAutoType}}checked{{/if}} />
+            <label for="settings__general-lock-on-auto-type">{{res 'setGenLockAutoType'}}</label>
+        </div>
         {{/if}}
-        <button class="btn-silent settings__general-show-logs-link">{{res 'setGenShowAppLogs'}}</button>
-    </div>
+        {{#if canDetectOsSleep}}
+            <div class="settings__check-row">
+                <input type="checkbox" class="settings__input input-base settings__general-lock-on-os-lock" id="settings__general-lock-on-os-lock" {{#if lockOnOsLock}}checked{{/if}} />
+                <label for="settings__general-lock-on-os-lock">{{res 'setGenLockOrSleep'}}</label>
+            </div>
+        {{/if}}
+    </section>
+
+    <section class="settings__section" id="storage">
+        <h2>{{res 'setGenStorage'}}</h2>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-disable-offline-storage" id="settings__general-disable-offline-storage" {{#if disableOfflineStorage}}checked{{/if}} />
+            <label for="settings__general-disable-offline-storage">{{res 'setGenDisableOfflineStorage'}}</label>
+        </div>
+        <div class="settings__check-row">
+            <input type="checkbox" class="settings__input input-base settings__general-short-lived-storage-token" id="settings__general-short-lived-storage-token" {{#if shortLivedStorageToken}}checked{{/if}} />
+            <label for="settings__general-short-lived-storage-token">{{res 'setGenShortLivedStorageToken'}}</label>
+        </div>
+
+        {{#each storageProviders as |prv|}}
+        <div class="settings__general-prv">
+            <h4 class="settings__general-storage-header">
+                <input type="checkbox" id="settings__general-prv-check-{{prv.name}}" class="settings__general-prv-check" data-storage="{{prv.name}}" {{#if prv.enabled}}checked{{/if}} />
+                <label for="settings__general-prv-check-{{prv.name}}">{{res prv.name}}</label>
+            </h4>
+            <div class="settings__general-prv-wrap settings__general-{{prv.name}} {{#ifeq prv.enabled false}}hide{{/ifeq}}"></div>
+            {{#if prv.loggedIn}}<button class="btn-silent settings__general-prv-logout" data-storage="{{prv.name}}">{{res 'setGenStorageLogout'}}</button>{{/if}}
+        </div>
+        {{/each}}
+    </section>
+
+    <section class="settings__section" id="advanced">
+        <h2>{{res 'advanced'}}</h2>
+        <a class="settings__general-show-advanced">{{res 'setGenShowAdvanced'}}</a>
+        <div class="settings__general-advanced hide settings__general-update-buttons">
+            {{#if devTools}}
+                <button class="btn-silent settings__general-dev-tools-link">{{res 'setGenDevTools'}}</button>
+                <button class="btn-silent settings__general-try-beta-link">{{res 'setGenTryBeta'}}</button>
+            {{/if}}
+            {{#if showReloadApp}}
+                <button class="btn-silent settings__general-reload-app-link">{{res 'setGenReloadApp'}}</button>
+            {{/if}}
+            <button class="btn-silent settings__general-show-logs-link">{{res 'setGenShowAppLogs'}}</button>
+        </div>
+    </section>
 </div>

--- a/app/templates/settings/settings-help.hbs
+++ b/app/templates/settings/settings-help.hbs
@@ -1,30 +1,44 @@
-<div class="settings__content">
-    <h1><i class="fa fa-question settings__head-icon"></i> {{res 'help'}}</h1>
-    <h2>{{res 'setHelpFormat'}}</h2>
-    <p>{{#res 'setHelpFormatBody'}}<a href="https://keepass.info/" target="_blank">KeePass</a>{{/res}}</p>
-    <h2>{{res 'setHelpProblems'}}</h2>
-    <p>{{#res 'setHelpProblems1'}} <a href="{{issueLink}}" target="_blank">{{res 'setHelpOpenIssue'}}</a>{{/res}}
-        {{#res 'setHelpProblems2'}}<a href="https://antelle.net/" target="_blank">{{res 'setHelpContactLink'}}</a>{{/res}}.
-    </p>
-    <p>{{res 'setHelpAppInfo'}}:</p>
-    <pre class="settings__pre input-base">{{appInfo}}</pre>
-    <h2>{{res 'setHelpOtherPlatforms'}}</h2>
-    <ul>
-        <li>
-            <i class="fa fa-windows"></i>
-            <i class="fa fa-apple"></i>
-            <i class="fa fa-linux"></i>
-            <a href="{{desktopLink}}" target="_blank">{{res 'setHelpDesktopApps'}}</a>
-        </li>
-        <li>
-            <i class="fa fa-chrome"></i>
-            <i class="fa fa-firefox-browser"></i>
-            <i class="fa fa-opera"></i>
-            <i class="fa fa-safari"></i>
-            <i class="fa fa-edge"></i>
-            <a href="{{webAppLink}}" target="_blank">{{res 'setHelpWebApp'}}</a>
-        </li>
-    </ul>
-    <h2>{{res 'setHelpUpdates'}} <i class="fa fa-twitter"></i></h2>
-    <p>{{res 'setHelpTwitter'}}: <a href="https://twitter.com/kee_web" target="_blank">kee_web</a></p>
+<div class="settings__content settings__content--cards">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-question settings__head-icon"></i> {{res 'help'}}</h1>
+    </section>
+
+    <section class="settings__section">
+        <h2>{{res 'setHelpFormat'}}</h2>
+        <p class="settings__meta">{{#res 'setHelpFormatBody'}}<a href="https://keepass.info/" target="_blank">KeePass</a>{{/res}}</p>
+    </section>
+
+    <section class="settings__section">
+        <h2>{{res 'setHelpProblems'}}</h2>
+        <p class="settings__meta">{{#res 'setHelpProblems1'}} <a href="{{issueLink}}" target="_blank">{{res 'setHelpOpenIssue'}}</a>{{/res}}
+            {{#res 'setHelpProblems2'}}<a href="https://antelle.net/" target="_blank">{{res 'setHelpContactLink'}}</a>{{/res}}.
+        </p>
+        <p class="settings__meta">{{res 'setHelpAppInfo'}}:</p>
+        <pre class="settings__pre input-base">{{appInfo}}</pre>
+    </section>
+
+    <section class="settings__section">
+        <h2>{{res 'setHelpOtherPlatforms'}}</h2>
+        <ul>
+            <li>
+                <i class="fa fa-windows"></i>
+                <i class="fa fa-apple"></i>
+                <i class="fa fa-linux"></i>
+                <a href="{{desktopLink}}" target="_blank">{{res 'setHelpDesktopApps'}}</a>
+            </li>
+            <li>
+                <i class="fa fa-chrome"></i>
+                <i class="fa fa-firefox-browser"></i>
+                <i class="fa fa-opera"></i>
+                <i class="fa fa-safari"></i>
+                <i class="fa fa-edge"></i>
+                <a href="{{webAppLink}}" target="_blank">{{res 'setHelpWebApp'}}</a>
+            </li>
+        </ul>
+    </section>
+
+    <section class="settings__section">
+        <h2>{{res 'setHelpUpdates'}} <i class="fa fa-twitter"></i></h2>
+        <p class="settings__meta">{{res 'setHelpTwitter'}}: <a href="https://twitter.com/kee_web" target="_blank">kee_web</a></p>
+    </section>
 </div>

--- a/app/templates/settings/settings-plugins.hbs
+++ b/app/templates/settings/settings-plugins.hbs
@@ -1,166 +1,182 @@
-<div class="settings__content">
-    <h1><i class="fa fa-puzzle-piece settings__head-icon"></i> {{res 'plugins'}}</h1>
-    <div>
-        {{res 'setPlDevelop'}} <a href="{{pluginDevLink}}" target="_blank">{{res 'setPlDevelopStart'}}</a>.
-        {{#res 'setPlTranslate'}}<a href="{{translateLink}}" target="_blank">{{res 'setPlTranslateLink'}}</a>{{/res}}.
-    </div>
-    <div class="settings__plugins-list">
-        {{#each plugins as |plugin|}}
-        <div class="settings__plugins-plugin" id="settings__plugins-plugin--{{plugin.id}}">
-            <h2>{{plugin.id}}</h2>
-            <div>{{plugin.manifest.description}}</div>
-            <div>
-                <ul class="settings__plugins-plugin-files">
-                    {{#if plugin.manifest.resources.js}}<li class="settings__plugins-plugin-file"><i class="fa fa-code"></i> {{res 'setPlJs'}}</li>{{/if}}
-                    {{#if plugin.manifest.resources.css}}<li class="settings__plugins-plugin-file"><i class="fa fa-paint-brush"></i> {{res 'setPlCss'}}</li>{{/if}}
-                    {{#if plugin.manifest.resources.loc}}<li class="settings__plugins-plugin-file"><i class="fa fa-language"></i>&nbsp;
-                        {{res 'setPlLoc'}}: {{plugin.manifest.locale.title}} {{#if ../hasUnicodeFlags}}{{#if plugin.manifest.locale}}{{#if plugin.manifest.locale.flag}}&nbsp;{{plugin.manifest.locale.flag}}{{/if}}{{/if}}{{/if}}</li>
-                    {{/if}}
-                </ul>
-            </div>
-            <div class="settings__plugins-plugin-desc">
-                <a href="{{plugin.manifest.url}}" target="_blank">{{plugin.manifest.url}}</a>, v{{plugin.manifest.version}}.
-                {{#if plugin.official}}
-                    {{res 'setPlOfficial'}},
-                {{else}}
-                    {{#res 'setPlCreatedBy'}}<a href="{{plugin.manifest.author.url}}" target="_blank">{{plugin.manifest.author.name}}</a> ({{plugin.manifest.author.email}}){{/res}},
-                {{/if}}
-                {{#ifeq plugin.status 'active'}}
-                    {{#res 'setPlLoadTime'}}{{plugin.installTime}}ms{{/res}}
-                {{else}}
-                    {{#ifeq plugin.status 'error'}}
-                        <span class="error-color">&nbsp;{{res 'setPlLoadError'}}</span>
-                    {{else}}
-                        {{plugin.status}}
-                    {{/ifeq}}
-                {{/ifeq}}
-                {{#if updateCheckDate}}
-                    <div>{{res 'setPlLastUpdate'}}: {{updateCheckDate}}</div>
-                {{/if}}
-                {{#if plugin.installError}}<div class="error-color settings__plugins-install-error"><pre>{{plugin.installError}}</pre></div>{{/if}}
-                {{#if plugin.updateError}}<div class="error-color settings__plugins-install-error"><pre>{{plugin.updateError}}</pre></div>{{/if}}
-            </div>
-            <div class="settings__plugins-plugin-updates">
-                <input type="checkbox" class="settings__plugins-plugin-update-check settings__input input-base"
-                    id="plugin-{{plugin.id}}-auto-update" data-plugin="{{plugin.id}}"
-                    {{#if plugin.autoUpdate}}checked{{/if}} />
-                <label for="plugin-{{plugin.id}}-auto-update">{{res 'setPlAutoUpdate'}}</label>
-            </div>
-            {{#if plugin.settings}}
-                <div class="settings__plugins-plugin-settings">
-                    {{#each plugin.settings as |setting|}}
-                    <div class="settings__plugins-plugin-setting"
-                         data-setting="{{setting.name}}"
-                         data-plugin="{{../id}}"
-                    >
-                        {{#ifeq setting.type 'checkbox'}}
-                            <input type="checkbox"
-                                   class="settings__plugins-plugin-input settings__input input-base"
-                                   id="plugin-{{../id}}-setting-{{setting.name}}"
-                                   {{#if setting.value}}checked{{/if}}
-                            />
-                        {{/ifeq}}
-                        <label
-                            class="settings__plugins-plugin-label"
-                            for="plugin-{{../id}}-setting-{{setting.name}}"
-                        >{{setting.label}}</label>
-                        {{#ifeq setting.type 'text'}}
-                            <input type="text"
-                                   class="settings__plugins-plugin-input settings__input input-base"
-                                   id="plugin-{{../id}}-setting-{{setting.name}}"
-                                   {{#if setting.placeholder}}placeholder="{{setting.placeholder}}"{{/if}}
-                                   {{#if setting.maxlength}}maxlength="{{setting.maxlength}}"{{/if}}
-                                   value="{{setting.value}}"
-                            />
-                        {{/ifeq}}
-                        {{#ifeq setting.type 'select'}}
-                            <select class="settings__plugins-plugin-input settings__select input-base"
-                                    id="plugin-{{../name}}-setting-{{setting.name}}"
-                            >
-                                {{#each setting.options as |opt|}}
-                                    <option value="{{opt.value}}" {{#ifeq opt.value ../value}}selected{{/ifeq}}>{{opt.label}}</option>
-                                {{/each}}
-                            </select>
-                        {{/ifeq}}
-                    </div>
-                    {{/each}}
-                </div>
-            {{/if}}
-            <div class="settings__plugins-plugin-buttons">
-                <button class="settings_plugins-uninstall-btn btn-error" data-plugin="{{plugin.id}}">{{res 'setPlUninstallBtn'}}</button>
-                {{#ifeq plugin.status 'active'}}<button class="settings_plugins-disable-btn btn-silent" data-plugin="{{plugin.id}}">{{res 'setPlDisableBtn'}}</button>{{/ifeq}}
-                {{#ifeq plugin.status 'inactive'}}<button class="settings_plugins-enable-btn btn-silent" data-plugin="{{plugin.id}}">{{res 'setPlEnableBtn'}}</button>{{/ifeq}}
-                <button class="settings_plugins-update-btn btn-silent" data-plugin="{{plugin.id}}">{{res 'setPlUpdateBtn'}}</button>
-                {{#ifeq plugin.status 'active'}}
-                    {{#if plugin.manifest.locale}}<button class="settings_plugins-use-locale-btn btn-silent" data-locale="{{plugin.manifest.locale.name}}">{{res 'setPlLocaleBtn'}}</button>{{/if}}
-                    {{#if plugin.manifest.theme}}<button class="settings_plugins-use-theme-btn btn-silent" data-theme="{{plugin.manifest.theme.name}}">{{res 'setPlThemeBtn'}}</button>{{/if}}
-                {{/ifeq}}
-            </div>
-        </div>
-        {{/each}}
-    </div>
-    <h2>
-        {{#if galleryLoading}}{{res 'setPlGalleryLoading'}}...{{else}}{{res 'setPlInstallTitle'}}{{/if}}
-    </h2>
-    <div class="settings__plugins-install">
-        <div>{{res 'setPlInstallDesc'}}</div>
-        {{#if galleryLoadError}}<div class="error-color">{{res 'setPlGalleryLoadError'}}</div>{{/if}}
-        {{#if galleryPlugins}}
-            <input type="text" class="input-base settings__plugins-gallery-search" placeholder="{{res 'setPlSearch'}}" value="{{searchStr}}" />
-            <div class="settings__plugins-gallery">
-            {{#each galleryPlugins as |plugin|}}
-                <div class="settings__plugins-gallery-plugin" data-plugin="{{plugin.manifest.name}}">
-                    <h4 class="settings__plugins-gallery-plugin-title">
-                        <a href="{{plugin.url}}" target="_blank" class="settings__plugins-gallery-plugin-title-link">{{plugin.manifest.name}}</a>
-                    </h4>
-                    {{#if ../hasUnicodeFlags}}
-                        {{#if plugin.manifest.locale}}
-                            {{#if plugin.manifest.locale.flag}}
-                                <div class="settings__plugins-gallery-plugin-country-flag">{{plugin.manifest.locale.flag}}</div>
-                            {{/if}}
-                        {{/if}}
-                    {{/if}}
-                    <div class="settings__plugins-gallery-plugin-desc">{{plugin.manifest.description}}</div>
+<div class="settings__content settings__content--cards">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-puzzle-piece settings__head-icon"></i> {{res 'plugins'}}</h1>
+        <p class="settings__meta">
+            {{res 'setPlDevelop'}} <a href="{{pluginDevLink}}" target="_blank">{{res 'setPlDevelopStart'}}</a>.
+            {{#res 'setPlTranslate'}}<a href="{{translateLink}}" target="_blank">{{res 'setPlTranslateLink'}}</a>{{/res}}.
+        </p>
+    </section>
+
+    <section class="settings__section">
+        <h2>{{res 'plugins'}}</h2>
+        <div class="settings__plugins-list">
+            {{#each plugins as |plugin|}}
+            <div class="settings__plugins-plugin" id="settings__plugins-plugin--{{plugin.id}}">
+                <h2>{{plugin.id}}</h2>
+                <div>{{plugin.manifest.description}}</div>
+                <div>
                     <ul class="settings__plugins-plugin-files">
                         {{#if plugin.manifest.resources.js}}<li class="settings__plugins-plugin-file"><i class="fa fa-code"></i> {{res 'setPlJs'}}</li>{{/if}}
                         {{#if plugin.manifest.resources.css}}<li class="settings__plugins-plugin-file"><i class="fa fa-paint-brush"></i> {{res 'setPlCss'}}</li>{{/if}}
-                        {{#if plugin.manifest.resources.loc}}<li class="settings__plugins-plugin-file"><i class="fa fa-language"></i> {{res 'setPlLoc'}}: {{plugin.manifest.locale.title}}</li>{{/if}}
+                        {{#if plugin.manifest.resources.loc}}<li class="settings__plugins-plugin-file"><i class="fa fa-language"></i>&nbsp;
+                            {{res 'setPlLoc'}}: {{plugin.manifest.locale.title}} {{#if ../hasUnicodeFlags}}{{#if plugin.manifest.locale}}{{#if plugin.manifest.locale.flag}}&nbsp;{{plugin.manifest.locale.flag}}{{/if}}{{/if}}{{/if}}</li>
+                        {{/if}}
                     </ul>
-                    <div class="settings__plugins-gallery-plugin-author muted-color">
-                        {{#if plugin.official}}
-                            <i class="fa fa-check"></i> {{res 'setPlOfficial'}}
-                        {{else}}
-                            <i class="fa fa-at"></i> <a href="{{plugin.manifest.author.url}}" target="_blank">{{plugin.manifest.author.name}}</a> ({{plugin.manifest.author.email}})
-                        {{/if}}
-                    </div>
-                    {{#if plugin.installError}}
-                        <div class="error-color">{{plugin.installError}}</div>
-                    {{/if}}
-                    <button class="settings__plugins-gallery-plugin-install-btn"
-                            data-plugin="{{plugin.manifest.name}}"
-                            {{#if plugin.installing}}disabled{{/if}}
-                    >
-                        {{#if plugin.installing}}
-                            {{res 'setPlInstallBtnProgress'}}...
-                        {{else}}
-                            {{res 'setPlInstallBtn'}}
-                        {{/if}}
-                    </button>
                 </div>
-            {{/each}}
+                <div class="settings__plugins-plugin-desc">
+                    <a href="{{plugin.manifest.url}}" target="_blank">{{plugin.manifest.url}}</a>, v{{plugin.manifest.version}}.
+                    {{#if plugin.official}}
+                        {{res 'setPlOfficial'}},
+                    {{else}}
+                        {{#res 'setPlCreatedBy'}}<a href="{{plugin.manifest.author.url}}" target="_blank">{{plugin.manifest.author.name}}</a> ({{plugin.manifest.author.email}}){{/res}},
+                    {{/if}}
+                    {{#ifeq plugin.status 'active'}}
+                        {{#res 'setPlLoadTime'}}{{plugin.installTime}}ms{{/res}}
+                    {{else}}
+                        {{#ifeq plugin.status 'error'}}
+                            <span class="error-color">&nbsp;{{res 'setPlLoadError'}}</span>
+                        {{else}}
+                            {{plugin.status}}
+                        {{/ifeq}}
+                    {{/ifeq}}
+                    {{#if updateCheckDate}}
+                        <div>{{res 'setPlLastUpdate'}}: {{updateCheckDate}}</div>
+                    {{/if}}
+                    {{#if plugin.installError}}<div class="error-color settings__plugins-install-error"><pre>{{plugin.installError}}</pre></div>{{/if}}
+                    {{#if plugin.updateError}}<div class="error-color settings__plugins-install-error"><pre>{{plugin.updateError}}</pre></div>{{/if}}
+                </div>
+                <div class="settings__plugins-plugin-updates">
+                    <input type="checkbox" class="settings__plugins-plugin-update-check settings__input input-base"
+                        id="plugin-{{plugin.id}}-auto-update" data-plugin="{{plugin.id}}"
+                        {{#if plugin.autoUpdate}}checked{{/if}} />
+                    <label for="plugin-{{plugin.id}}-auto-update">{{res 'setPlAutoUpdate'}}</label>
+                </div>
+                {{#if plugin.settings}}
+                    <div class="settings__plugins-plugin-settings">
+                        {{#each plugin.settings as |setting|}}
+                        <div class="settings__plugins-plugin-setting"
+                             data-setting="{{setting.name}}"
+                             data-plugin="{{../id}}"
+                        >
+                            {{#ifeq setting.type 'checkbox'}}
+                                <input type="checkbox"
+                                       class="settings__plugins-plugin-input settings__input input-base"
+                                       id="plugin-{{../id}}-setting-{{setting.name}}"
+                                       {{#if setting.value}}checked{{/if}}
+                                />
+                            {{/ifeq}}
+                            <label
+                                class="settings__plugins-plugin-label"
+                                for="plugin-{{../id}}-setting-{{setting.name}}"
+                            >{{setting.label}}</label>
+                            {{#ifeq setting.type 'text'}}
+                                <input type="text"
+                                       class="settings__plugins-plugin-input settings__input input-base"
+                                       id="plugin-{{../id}}-setting-{{setting.name}}"
+                                       {{#if setting.placeholder}}placeholder="{{setting.placeholder}}"{{/if}}
+                                       {{#if setting.maxlength}}maxlength="{{setting.maxlength}}"{{/if}}
+                                       value="{{setting.value}}"
+                                />
+                            {{/ifeq}}
+                            {{#ifeq setting.type 'select'}}
+                                <select class="settings__plugins-plugin-input settings__select input-base"
+                                        id="plugin-{{../name}}-setting-{{setting.name}}"
+                                >
+                                    {{#each setting.options as |opt|}}
+                                        <option value="{{opt.value}}" {{#ifeq opt.value ../value}}selected{{/ifeq}}>{{opt.label}}</option>
+                                    {{/each}}
+                                </select>
+                            {{/ifeq}}
+                        </div>
+                        {{/each}}
+                    </div>
+                {{/if}}
+                <div class="settings__plugins-plugin-buttons">
+                    <button class="settings_plugins-uninstall-btn btn-error" data-plugin="{{plugin.id}}">{{res 'setPlUninstallBtn'}}</button>
+                    {{#ifeq plugin.status 'active'}}<button class="settings_plugins-disable-btn btn-silent" data-plugin="{{plugin.id}}">{{res 'setPlDisableBtn'}}</button>{{/ifeq}}
+                    {{#ifeq plugin.status 'inactive'}}<button class="settings_plugins-enable-btn btn-silent" data-plugin="{{plugin.id}}">{{res 'setPlEnableBtn'}}</button>{{/ifeq}}
+                    <button class="settings_plugins-update-btn btn-silent" data-plugin="{{plugin.id}}">{{res 'setPlUpdateBtn'}}</button>
+                    {{#ifeq plugin.status 'active'}}
+                        {{#if plugin.manifest.locale}}<button class="settings_plugins-use-locale-btn btn-silent" data-locale="{{plugin.manifest.locale.name}}">{{res 'setPlLocaleBtn'}}</button>{{/if}}
+                        {{#if plugin.manifest.theme}}<button class="settings_plugins-use-theme-btn btn-silent" data-theme="{{plugin.manifest.theme.name}}">{{res 'setPlThemeBtn'}}</button>{{/if}}
+                    {{/ifeq}}
+                </div>
             </div>
-        {{else}}
-            <button class="settings__plugins-gallery-load-btn" {{#if galleryLoading}}disabled="disabled"{{/if}}>{{res 'setPlLoadGallery'}}</button>
-        {{/if}}
-    </div>
-    <h2>{{res 'setPlInstallUrlTitle'}}</h2>
-    <div class="settings__plugins-install-url">
-        <div>{{res 'setPlInstallUrlDesc'}}</div>
-        <label for="settings__plugins-install-url">{{res 'setPlInstallLabel'}}</label>
-        <input type="text" class="settings__input input-base" id="settings__plugins-install-url" value="{{installUrl}}" />
-        <button class="settings_plugins-install-btn" {{#if installingFromUrl}}disabled{{/if}}>
-            {{#if installingFromUrl}}{{res 'setPlInstallBtnProgress'}}{{else}}{{res 'setPlInstallBtn'}}{{/if}}
-        </button>
-        <div class="error-color settings__plugins-install-error">{{installUrlError}}</div>
-    </div>
+            {{/each}}
+        </div>
+    </section>
+
+    <section class="settings__section">
+        <h2>
+            {{#if galleryLoading}}{{res 'setPlGalleryLoading'}}...{{else}}{{res 'setPlInstallTitle'}}{{/if}}
+        </h2>
+        <div class="settings__plugins-install">
+            <div>{{res 'setPlInstallDesc'}}</div>
+            {{#if galleryLoadError}}<div class="error-color">{{res 'setPlGalleryLoadError'}}</div>{{/if}}
+            {{#if galleryPlugins}}
+                <input type="text" class="input-base settings__plugins-gallery-search" placeholder="{{res 'setPlSearch'}}" value="{{searchStr}}" />
+                <div class="settings__plugins-gallery">
+                {{#each galleryPlugins as |plugin|}}
+                    <div class="settings__plugins-gallery-plugin" data-plugin="{{plugin.manifest.name}}">
+                        <h4 class="settings__plugins-gallery-plugin-title">
+                            <a href="{{plugin.url}}" target="_blank" class="settings__plugins-gallery-plugin-title-link">{{plugin.manifest.name}}</a>
+                        </h4>
+                        {{#if ../hasUnicodeFlags}}
+                            {{#if plugin.manifest.locale}}
+                                {{#if plugin.manifest.locale.flag}}
+                                    <div class="settings__plugins-gallery-plugin-country-flag">{{plugin.manifest.locale.flag}}</div>
+                                {{/if}}
+                            {{/if}}
+                        {{/if}}
+                        <div class="settings__plugins-gallery-plugin-desc">{{plugin.manifest.description}}</div>
+                        <ul class="settings__plugins-plugin-files">
+                            {{#if plugin.manifest.resources.js}}<li class="settings__plugins-plugin-file"><i class="fa fa-code"></i> {{res 'setPlJs'}}</li>{{/if}}
+                            {{#if plugin.manifest.resources.css}}<li class="settings__plugins-plugin-file"><i class="fa fa-paint-brush"></i> {{res 'setPlCss'}}</li>{{/if}}
+                            {{#if plugin.manifest.resources.loc}}<li class="settings__plugins-plugin-file"><i class="fa fa-language"></i> {{res 'setPlLoc'}}: {{plugin.manifest.locale.title}}</li>{{/if}}
+                        </ul>
+                        <div class="settings__plugins-gallery-plugin-author muted-color">
+                            {{#if plugin.official}}
+                                <i class="fa fa-check"></i> {{res 'setPlOfficial'}}
+                            {{else}}
+                                <i class="fa fa-at"></i> <a href="{{plugin.manifest.author.url}}" target="_blank">{{plugin.manifest.author.name}}</a> ({{plugin.manifest.author.email}})
+                            {{/if}}
+                        </div>
+                        {{#if plugin.installError}}
+                            <div class="error-color">{{plugin.installError}}</div>
+                        {{/if}}
+                        <button class="settings__plugins-gallery-plugin-install-btn"
+                                data-plugin="{{plugin.manifest.name}}"
+                                {{#if plugin.installing}}disabled{{/if}}
+                        >
+                            {{#if plugin.installing}}
+                                {{res 'setPlInstallBtnProgress'}}...
+                            {{else}}
+                                {{res 'setPlInstallBtn'}}
+                            {{/if}}
+                        </button>
+                    </div>
+                {{/each}}
+                </div>
+            {{else}}
+                <button class="settings__plugins-gallery-load-btn" {{#if galleryLoading}}disabled="disabled"{{/if}}>{{res 'setPlLoadGallery'}}</button>
+            {{/if}}
+        </div>
+    </section>
+
+    <section class="settings__section">
+        <h2>{{res 'setPlInstallUrlTitle'}}</h2>
+        <div class="settings__plugins-install-url">
+            <p class="settings__meta">{{res 'setPlInstallUrlDesc'}}</p>
+            <div class="settings__field">
+                <label for="settings__plugins-install-url">{{res 'setPlInstallLabel'}}</label>
+                <input type="text" class="settings__input input-base" id="settings__plugins-install-url" value="{{installUrl}}" />
+            </div>
+            <div class="settings__general-update-buttons">
+                <button class="settings_plugins-install-btn" {{#if installingFromUrl}}disabled{{/if}}>
+                    {{#if installingFromUrl}}{{res 'setPlInstallBtnProgress'}}{{else}}{{res 'setPlInstallBtn'}}{{/if}}
+                </button>
+            </div>
+            <div class="error-color settings__plugins-install-error">{{installUrlError}}</div>
+        </div>
+    </section>
 </div>

--- a/app/templates/settings/settings-shortcuts.hbs
+++ b/app/templates/settings/settings-shortcuts.hbs
@@ -1,38 +1,46 @@
-<div class="settings__content">
-    <h1><i class="fa fa-keyboard settings__head-icon"></i> {{res 'setShTitle'}}</h1>
-    <div><span class="shortcut">{{cmd}}A</span> {{res 'or'}} <span class="shortcut">{{alt}}A</span> {{res 'setShShowAll'}}</div>
-    <div><span class="shortcut">{{alt}}C</span> {{res 'setShColors'}}</div>
-    <div><span class="shortcut">{{alt}}D</span> {{res 'setShTrash'}}</div>
-    <div><span class="shortcut">{{cmd}}F</span> {{res 'setShFind'}}</div>
-    <div><span class="shortcut">esc</span> {{res 'setShClearSearch'}}</div>
-    <div><span class="shortcut">{{cmd}}C</span> {{res 'setShCopyPass'}}</div>
-    <div><span class="shortcut">{{cmd}}B</span> {{res 'setShCopyUser'}}</div>
-    <div><span class="shortcut">{{cmd}}U</span> {{res 'setShCopyUrl'}}</div>
-    <div><span class="shortcut">{{alt}}2</span> {{res 'setShCopyOtp'}}</div>
-    {{#if autoTypeSupported}}
-        <div><span class="shortcut">{{cmd}}T</span> {{res 'setShAutoType'}}</div>
-    {{/if}}
-    <div><span class="shortcut">&uarr;</span> {{res 'setShPrev'}}</div>
-    <div><span class="shortcut">&darr;</span> {{res 'setShNext'}}</div>
-    <div><span class="shortcut">{{alt}}N</span> {{res 'setShCreateEntry'}}</div>
-    <div><span class="shortcut">{{cmd}}O</span> {{res 'setShOpen'}}</div>
-    <div><span class="shortcut">{{cmd}}S</span> {{res 'setShSave'}}</div>
-    <div><span class="shortcut">{{cmd}}G</span> {{res 'setShGen'}}</div>
-    <div><span class="shortcut">{{cmd}},</span> {{res 'setShSet'}}</div>
-    <div><span class="shortcut">{{cmd}}L</span> {{res 'setShLock'}}</div>
+<div class="settings__content settings__content--cards">
+    <section class="settings__section settings__section--header">
+        <h1 class="settings__title"><i class="fa fa-keyboard settings__head-icon"></i> {{res 'setShTitle'}}</h1>
+    </section>
+
+    <section class="settings__section">
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}A</span> {{res 'or'}} <span class="shortcut">{{alt}}A</span> {{res 'setShShowAll'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{alt}}C</span> {{res 'setShColors'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{alt}}D</span> {{res 'setShTrash'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}F</span> {{res 'setShFind'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">esc</span> {{res 'setShClearSearch'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}C</span> {{res 'setShCopyPass'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}B</span> {{res 'setShCopyUser'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}U</span> {{res 'setShCopyUrl'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{alt}}2</span> {{res 'setShCopyOtp'}}</div>
+        {{#if autoTypeSupported}}
+            <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}T</span> {{res 'setShAutoType'}}</div>
+        {{/if}}
+        <div class="settings__shortcut-row"><span class="shortcut">&uarr;</span> {{res 'setShPrev'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">&darr;</span> {{res 'setShNext'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{alt}}N</span> {{res 'setShCreateEntry'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}O</span> {{res 'setShOpen'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}S</span> {{res 'setShSave'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}G</span> {{res 'setShGen'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}},</span> {{res 'setShSet'}}</div>
+        <div class="settings__shortcut-row"><span class="shortcut">{{cmd}}L</span> {{res 'setShLock'}}</div>
+    </section>
+
     {{#if globalShortcuts}}
-        <p>{{res 'setShGlobal'}}</p>
-        <div><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
-                     data-shortcut="autoType">{{globalShortcuts.autoType}}</button> {{res 'setShAutoTypeGlobal'}}</div>
-        <div><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
-                     data-shortcut="copyPassword">{{globalShortcuts.copyPassword}}</button> {{res 'setShCopyPassOnly'}}</div>
-        <div><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
-                     data-shortcut="copyUser">{{globalShortcuts.copyUser}}</button> {{res 'setShCopyUser'}}</div>
-        <div><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
-                     data-shortcut="copyUrl">{{globalShortcuts.copyUrl}}</button> {{res 'setShCopyUrl'}}</div>
-        <div><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
-                     data-shortcut="copyOtp">{{globalShortcuts.copyOtp}}</button> {{res 'setShCopyOtp'}}</div>
-        <div><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
-                     data-shortcut="restoreApp">{{globalShortcuts.restoreApp}}</button> {{#res 'setShRestoreApp'}}KeeWeb{{/res}}</div>
+        <section class="settings__section">
+            <h2>{{res 'setShGlobal'}}</h2>
+            <div class="settings__shortcut-row"><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
+                         data-shortcut="autoType">{{globalShortcuts.autoType}}</button> {{res 'setShAutoTypeGlobal'}}</div>
+            <div class="settings__shortcut-row"><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
+                         data-shortcut="copyPassword">{{globalShortcuts.copyPassword}}</button> {{res 'setShCopyPassOnly'}}</div>
+            <div class="settings__shortcut-row"><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
+                         data-shortcut="copyUser">{{globalShortcuts.copyUser}}</button> {{res 'setShCopyUser'}}</div>
+            <div class="settings__shortcut-row"><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
+                         data-shortcut="copyUrl">{{globalShortcuts.copyUrl}}</button> {{res 'setShCopyUrl'}}</div>
+            <div class="settings__shortcut-row"><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
+                         data-shortcut="copyOtp">{{globalShortcuts.copyOtp}}</button> {{res 'setShCopyOtp'}}</div>
+            <div class="settings__shortcut-row"><button class="shortcut btn-silent {{#if globalIsLarge}}shortcut-large{{/if}}"
+                         data-shortcut="restoreApp">{{globalShortcuts.restoreApp}}</button> {{#res 'setShRestoreApp'}}KeeWeb{{/res}}</div>
+        </section>
     {{/if}}
 </div>


### PR DESCRIPTION
## Summary
- modernize settings pages with a consistent card-based layout
- normalize field alignment and spacing for better readability
- improve responsive behavior (small windows) with cleaner section margins/padding
- apply the same visual direction across major settings sections

## Scope
- `app/styles/areas/_settings.scss`
- `app/templates/settings/settings-general.hbs`
- `app/templates/settings/settings-shortcuts.hbs`
- `app/templates/settings/settings-browser.hbs`
- `app/templates/settings/settings-plugins.hbs`
- `app/templates/settings/settings-devices.hbs`
- `app/templates/settings/settings-about.hbs`
- `app/templates/settings/settings-help.hbs`
- `app/templates/settings/settings-file.hbs`

## Explicitly out of scope
- no signing/provisioning/certificate changes
- no app bundle identity/team-specific changes
- no Touch ID logic changes

## Notes
- local lint/test run was not executed in this PR branch because dependencies are not installed in this environment
