### PR TITLE
chore: setup dependabot for github actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
### Setup Dependabot for Github Actions

We should have all the dependencies updated automatically. 

- First step is to setup Github Actions updates, which this PR includes. 
> "groups" means we will have 1 summarized Pull Request instead of multiple (in case of multiple package updates)


- Second step is to have JS packages autoupdated.
But its better to do it manually first as project is too outdated. 
Then we could setup dependabot too.