### PR TITLE
fix: KDBX 4.1 database corruption on save (LastModificationTime encoding)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^5.2.4",
         "css-minimizer-webpack-plugin": "^8.0.0",
-        "dompurify": "^2.2.8",
+        "dompurify": "^3.4.2",
         "electron": "^13.6.9",
         "electron-builder": "^23.6.0",
         "electron-evil-feature-patcher": "^1.2.1",
@@ -1986,6 +1986,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -6452,9 +6459,13 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/dompurify": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
-      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "9.0.2",
@@ -21372,6 +21383,12 @@
         }
       }
     },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -24674,9 +24691,12 @@
       }
     },
     "dompurify": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
-      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "dotenv": {
       "version": "9.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "jquery": "3.6.0",
         "json-loader": "^0.5.7",
         "jsqrcode": "github:antelle/jsqrcode#0.1.3",
-        "kdbxweb": "^2.0.4",
+        "kdbxweb": "github:intresrl/keepass-kdbxweb#intresrl",
         "load-grunt-tasks": "5.1.0",
         "lodash": "^4.17.21",
         "marked": "^2.0.3",
@@ -8294,6 +8294,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12463,22 +12469,28 @@
       }
     },
     "node_modules/kdbxweb": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/kdbxweb/-/kdbxweb-2.0.4.tgz",
-      "integrity": "sha512-Ckb3shx9E+VX6WZSvT6kJJknTA10T21M4HP8Z/xanZ65mwyQf7Mv0UreK/NUsa9BaejWEiB/QJxkTzrQZRn9Lg==",
+      "version": "2.2.1",
+      "resolved": "git+ssh://git@github.com/intresrl/keepass-kdbxweb.git#0af4558f0c59dab04202aeec6e75efe5e8dd8e0e",
+      "license": "MIT",
       "dependencies": {
-        "pako": "github:keeweb/pako#653c0b00d8941c89d09ed4546d2179001ec44efc",
-        "xmldom": "github:keeweb/xmldom#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
+        "@xmldom/xmldom": "^0.8.10",
+        "fflate": "^0.7.1"
+      },
+      "engines": {
+        "node": "^18.18.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/antelle"
       }
     },
-    "node_modules/kdbxweb/node_modules/xmldom": {
-      "resolved": "git+https://git@github.com/keeweb/xmldom.git#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6",
+    "node_modules/kdbxweb/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.1"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/keytar": {
@@ -14342,9 +14354,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pako": {
-      "resolved": "git+https://git@github.com/keeweb/pako.git#653c0b00d8941c89d09ed4546d2179001ec44efc"
     },
     "node_modules/param-case": {
       "version": "2.1.1",
@@ -26067,6 +26076,11 @@
         "pend": "~1.2.0"
       }
     },
+    "fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -29237,17 +29251,17 @@
       }
     },
     "kdbxweb": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/kdbxweb/-/kdbxweb-2.0.4.tgz",
-      "integrity": "sha512-Ckb3shx9E+VX6WZSvT6kJJknTA10T21M4HP8Z/xanZ65mwyQf7Mv0UreK/NUsa9BaejWEiB/QJxkTzrQZRn9Lg==",
+      "version": "git+ssh://git@github.com/intresrl/keepass-kdbxweb.git#0af4558f0c59dab04202aeec6e75efe5e8dd8e0e",
+      "from": "kdbxweb@github:intresrl/keepass-kdbxweb#intresrl",
       "requires": {
-        "pako": "github:keeweb/pako#653c0b00d8941c89d09ed4546d2179001ec44efc",
-        "xmldom": "github:keeweb/xmldom#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
+        "@xmldom/xmldom": "^0.8.10",
+        "fflate": "^0.7.1"
       },
       "dependencies": {
-        "xmldom": {
-          "version": "git+https://git@github.com/keeweb/xmldom.git#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6",
-          "from": "xmldom@github:keeweb/xmldom#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
+        "@xmldom/xmldom": {
+          "version": "0.8.13",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+          "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="
         }
       }
     },
@@ -30679,10 +30693,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    },
-    "pako": {
-      "version": "git+https://git@github.com/keeweb/pako.git#653c0b00d8941c89d09ed4546d2179001ec44efc",
-      "from": "pako@github:keeweb/pako#653c0b00d8941c89d09ed4546d2179001ec44efc"
     },
     "param-case": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
-    "dompurify": "^2.2.8",
+    "dompurify": "^3.4.2",
     "electron": "^13.6.9",
     "electron-builder": "^23.6.0",
     "electron-evil-feature-patcher": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jquery": "3.6.0",
     "json-loader": "^0.5.7",
     "jsqrcode": "github:antelle/jsqrcode#0.1.3",
-    "kdbxweb": "^2.0.4",
+    "kdbxweb": "github:intresrl/keepass-kdbxweb#intresrl",
     "load-grunt-tasks": "5.1.0",
     "lodash": "^4.17.21",
     "marked": "^2.0.3",


### PR DESCRIPTION
## ⚠️ This PR changes the kdbxweb dependency to a fork

```diff
- "kdbxweb": "^2.0.4",
+ "kdbxweb": "github:intresrl/keepass-kdbxweb#intresrl",
```

This is intentional and temporary. The fix has been submitted to kdbxweb upstream as **[keeweb/kdbxweb#62](https://github.com/keeweb/kdbxweb/pull/62)**. Once that PR is merged and a new official release is cut, this PR can be updated to point to the official package. The fork exists solely to unblock users today.

---

## Problem — KDBX 4.1 non-conformant output on save

`LastModificationTime` fields in `CustomData` and `CustomIcons` are written as ISO-8601 strings instead of the 8-byte little-endian Base64 binary required by the KDBX 4+ spec.

Originally reported in [keeweb/kdbxweb#49](https://github.com/keeweb/kdbxweb/issues/49) as causing KeePass / KeePassXC to reject saved files with *"Invalid Base-64 string"*. In our testing with current KeePassXC releases, the app appears to have since added a fallback that tolerates both formats — so immediate breakage may be limited to older clients or original KeePass on Windows. The fix is still correct: it brings kdbxweb output into spec compliance regardless of client leniency.

## Also included — DOMPurify 2 → 3

DOMPurify 2.x has known XSS CVEs. Version 3 is a drop-in upgrade: the `sanitize()` call in `md-to-html.js` is identical in both versions.

## Verification

- kdbxweb unit + integration tests pass (see [keeweb/kdbxweb#62](https://github.com/keeweb/kdbxweb/pull/62))
- `grunt` build passes
- Saved KDBX 4.1 file opens correctly in KeePassXC after the fix