### PR TITLE
Fix sync race that silently drops entry fields typed during upload

### DIFF
--- a/app/scripts/models/app-model.js
+++ b/app/scripts/models/app-model.js
@@ -947,12 +947,21 @@ class AppModel {
             });
         }
         file.setSyncProgress();
+        // Snapshot the modification counter at the moment the to-be-synced data is
+        // serialized. Updated right before each getData() below; compared on
+        // completion to detect edits that happened during the sync.
+        let dataModificationId = file.modificationId;
         const complete = (err) => {
             if (!file.active) {
                 return callback && callback('File is closed');
             }
             logger.info('Sync finished', err || 'no error');
-            file.setSyncComplete(path, storage, err ? err.toString() : null);
+            const editedDuringSync = file.modificationId !== dataModificationId;
+            file.setSyncComplete(path, storage, err ? err.toString() : null, editedDuringSync);
+            if (!err && editedDuringSync) {
+                logger.info('File was modified during sync, scheduling another sync');
+                setTimeout(() => this.syncFile(file), 0);
+            }
             fileInfo.set({
                 name: file.name,
                 storage,
@@ -983,6 +992,7 @@ class AppModel {
                 return complete();
             }
             logger.info('Local, save to cache');
+            dataModificationId = file.modificationId;
             file.getData((data, err) => {
                 if (err) {
                     return complete(err);
@@ -1086,6 +1096,7 @@ class AppModel {
             };
             const saveToCacheAndStorage = () => {
                 logger.info('Getting file data for saving');
+                dataModificationId = file.modificationId;
                 file.getData((data, err) => {
                     if (err) {
                         return complete(err);

--- a/app/scripts/models/entry-model.js
+++ b/app/scripts/models/entry-model.js
@@ -182,6 +182,10 @@ class EntryModel extends Model {
     }
 
     _entryModified() {
+        // Bump on every edit (even before the entry's first save) so edits made
+        // while a sync is in progress are detected by setSyncComplete. The unsaved
+        // guard below only controls history snapshots, not modification tracking.
+        this.file.registerModification();
         if (!this.unsaved) {
             this.unsaved = true;
             if (this.file.historyMaxItems !== 0) {

--- a/app/scripts/models/file-model.js
+++ b/app/scripts/models/file-model.js
@@ -412,8 +412,17 @@ class FileModel extends Model {
 
     setModified() {
         if (!this.demo) {
+            this.registerModification();
             this.set({ modified: true, dirty: true });
         }
+    }
+
+    // Monotonic counter bumped on every change to the database. Sync uses it to
+    // detect edits that arrive after the data snapshot was taken (see syncFile /
+    // setSyncComplete), so changes made mid-sync are not silently marked as saved.
+    // Bumped silently to avoid emitting a change event on every keystroke.
+    registerModification() {
+        this.set({ modificationId: this.modificationId + 1 }, { silent: true });
     }
 
     getData(cb) {
@@ -468,17 +477,20 @@ class FileModel extends Model {
         this.set({ syncing: true });
     }
 
-    setSyncComplete(path, storage, error) {
-        if (!error) {
+    setSyncComplete(path, storage, error, editedDuringSync) {
+        // When the database was edited after the synced snapshot was taken, those
+        // changes were not uploaded. Keep the file marked as modified/dirty (and
+        // preserve the local edit state for merging) so the caller can sync again,
+        // instead of treating the un-uploaded edits as saved.
+        if (!error && !editedDuringSync) {
             this.db.removeLocalEditState();
         }
-        const modified = this.modified && !!error;
         this.set({
             created: false,
             path: path || this.path,
             storage: storage || this.storage,
-            modified,
-            dirty: error ? this.dirty : false,
+            modified: error ? this.modified : !!editedDuringSync,
+            dirty: error ? this.dirty : !!editedDuringSync,
             syncing: false,
             syncError: error
         });
@@ -490,11 +502,16 @@ class FileModel extends Model {
             });
         }
 
-        if (!this.open) {
+        if (!this.active) {
             return;
         }
         this.setOpenFile({ passwordLength: this.passwordLength });
-        this.forEachEntry({ includeDisabled: true }, (entry) => entry.setSaved());
+        // If edits arrived during the sync we don't know which entries they touched,
+        // so leave all entries marked unsaved; the scheduled follow-up sync will
+        // clear them once it completes without concurrent edits.
+        if (!editedDuringSync) {
+            this.forEachEntry({ includeDisabled: true }, (entry) => entry.setSaved());
+        }
     }
 
     setPassword(password) {
@@ -739,6 +756,7 @@ FileModel.defineModelProperties({
     storage: null,
     modified: false,
     dirty: false,
+    modificationId: 0,
     active: false,
     created: false,
     demo: false,

--- a/test/src/models/file-model.js
+++ b/test/src/models/file-model.js
@@ -1,0 +1,158 @@
+import { expect } from 'chai';
+import * as kdbxweb from 'kdbxweb';
+import { FileModel } from 'models/file-model';
+import { EntryModel } from 'models/entry-model';
+
+// These tests cover the sync race that could push an entry to storage before its
+// username/password were typed, and then mark the file as fully synced (silently
+// dropping the un-uploaded fields). The fix tracks a modification counter so a
+// sync can tell whether the database was edited after its data snapshot was taken.
+describe('FileModel sync race', () => {
+    const createFile = () => {
+        const file = new FileModel({ id: 'f1' });
+        file.create('test', () => {});
+        return file;
+    };
+
+    describe('modificationId', () => {
+        it('starts at zero on a freshly created file', () => {
+            const file = createFile();
+            expect(file.modificationId).to.eql(0);
+        });
+
+        it('is bumped by setModified', () => {
+            const file = createFile();
+            file.setModified();
+            expect(file.modificationId).to.be.above(0);
+        });
+
+        it('is bumped silently, without emitting a change event', () => {
+            const file = createFile();
+            let changed = false;
+            file.on('change', () => {
+                changed = true;
+            });
+            file.on('change:modificationId', () => {
+                changed = true;
+            });
+            file.registerModification();
+            expect(file.modificationId).to.eql(1);
+            expect(changed).to.be.false;
+        });
+
+        // The critical regression: typing into a just-created (still "unsaved")
+        // entry used to skip the modification path entirely, so a sync in flight
+        // could not tell that new data had arrived.
+        it('is bumped on every entry edit, even before the entry is first saved', () => {
+            const file = createFile();
+            const group = file.groups[0];
+            const entry = EntryModel.newEntry(group, file);
+            const afterCreate = file.modificationId;
+
+            entry.setField('UserName', 'alice');
+            const afterUser = file.modificationId;
+
+            entry.setField('Password', kdbxweb.ProtectedValue.fromString('secret'));
+            const afterPassword = file.modificationId;
+
+            expect(entry.unsaved).to.be.true;
+            expect(afterUser).to.be.above(afterCreate);
+            expect(afterPassword).to.be.above(afterUser);
+        });
+    });
+
+    describe('setSyncComplete', () => {
+        it('clears modified/dirty and drops the edit state on a clean sync', () => {
+            const file = createFile();
+            file.setModified();
+            let editStateRemoved = 0;
+            file.db.removeLocalEditState = () => editStateRemoved++;
+
+            file.setSyncComplete('path', 'webdav', null, false);
+
+            expect(file.modified).to.be.false;
+            expect(file.dirty).to.be.false;
+            expect(file.syncing).to.be.false;
+            expect(file.syncError).to.be.null;
+            expect(editStateRemoved).to.eql(1);
+        });
+
+        it('keeps the file modified and preserves the edit state when edited during the sync', () => {
+            const file = createFile();
+            file.setModified();
+            let editStateRemoved = 0;
+            file.db.removeLocalEditState = () => editStateRemoved++;
+
+            file.setSyncComplete('path', 'webdav', null, true);
+
+            expect(file.modified).to.be.true;
+            expect(file.dirty).to.be.true;
+            expect(file.syncing).to.be.false;
+            expect(file.syncError).to.be.null;
+            expect(editStateRemoved).to.eql(0);
+        });
+
+        it('marks entries saved on a clean sync', () => {
+            const file = createFile();
+            const entry = EntryModel.newEntry(file.groups[0], file);
+            expect(entry.unsaved).to.be.true;
+
+            file.setSyncComplete('path', 'webdav', null, false);
+
+            expect(entry.unsaved).to.be.false;
+        });
+
+        it('leaves entries unsaved when edited during the sync', () => {
+            const file = createFile();
+            const entry = EntryModel.newEntry(file.groups[0], file);
+            expect(entry.unsaved).to.be.true;
+
+            file.setSyncComplete('path', 'webdav', null, true);
+
+            expect(entry.unsaved).to.be.true;
+        });
+    });
+
+    // End-to-end reproduction of the reported behaviour, following the exact
+    // sequence syncFile performs: snapshot the data, then (while the upload is in
+    // flight) the user fills in the fields, then the sync completes.
+    describe('the empty-entry race', () => {
+        it('does not treat edits made between snapshot and completion as saved', () => {
+            const file = createFile();
+            const entry = EntryModel.newEntry(file.groups[0], file);
+
+            // syncFile serializes the data here — only the empty entry is captured.
+            const dataModificationId = file.modificationId;
+
+            // The WebDAV upload is in flight; the user types the credentials.
+            entry.setField('UserName', 'alice');
+            entry.setField('Password', kdbxweb.ProtectedValue.fromString('secret'));
+
+            // syncFile computes this on completion and passes it to setSyncComplete.
+            const editedDuringSync = file.modificationId !== dataModificationId;
+            expect(editedDuringSync).to.be.true;
+
+            file.setSyncComplete('path', 'webdav', null, editedDuringSync);
+
+            // The credentials are not silently considered synced — another sync is due.
+            expect(file.modified).to.be.true;
+            expect(file.dirty).to.be.true;
+            expect(entry.unsaved).to.be.true;
+        });
+
+        it('regression check: a sync with no concurrent edits clears the modified state', () => {
+            const file = createFile();
+            EntryModel.newEntry(file.groups[0], file);
+
+            const dataModificationId = file.modificationId;
+            // No edits happen during the sync.
+            const editedDuringSync = file.modificationId !== dataModificationId;
+            expect(editedDuringSync).to.be.false;
+
+            file.setSyncComplete('path', 'webdav', null, editedDuringSync);
+
+            expect(file.modified).to.be.false;
+            expect(file.dirty).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
## Problem

When creating a new entry over WebDAV, typing the username/password
while a sync was already in flight caused those fields to be silently
lost. The sync serialized the empty entry, uploaded it, then marked the
file as fully synced — treating the un-uploaded credentials as if they
had been saved.

Two bugs combined to cause this:

1. `setSyncComplete` cleared `modified`/`dirty` and swept all entries
   to `saved` based only on whether an error occurred, with no awareness
   of edits that arrived after the data snapshot was taken.

2. `_entryModified`'s `unsaved` guard caused a brand-new entry's very
   first edits to bypass modification tracking entirely — so an in-flight
   sync had no signal that new data had arrived.

## Fix

**Monotonic modification counter** — `FileModel` gains a `modificationId`
property (default `0`). `registerModification()` increments it silently
(no change event) on every database edit.

**Snapshot before serialization** — `syncFile` captures `modificationId`
immediately before each `getData()` call. On completion it compares the
current counter to the snapshot:

- If equal → clean sync, existing behaviour unchanged.
- If advanced → `editedDuringSync=true` passed to `setSyncComplete`:
  `modified`/`dirty` stay true, `removeLocalEditState` is skipped, the
  entries-saved sweep is skipped, and a follow-up sync is scheduled via
  `setTimeout` so the un-uploaded fields are flushed automatically.

**Unconditional bump in `_entryModified`** — `registerModification()` is
called at the very top, before the `unsaved` guard, so a new entry's
first keystroke is always visible to a concurrent sync.

**Dead guard fix** — `if (!this.open)` in `setSyncComplete` checked
whether the method exists (always truthy). Changed to `if (!this.active)`
so a file closed mid-sync no longer reaches `forEachEntry`.

## Testing
New test suite `test/src/models/file-model.js` (10 tests, all passing):

- `modificationId` mechanics: starts at 0, bumped by `setModified`,
  bumped silently without emitting change events, bumped on entry edits
  even before first save (the regression case).
- `setSyncComplete` branches: clean sync clears state and drops edit
  state; edited-during-sync keeps `modified`/`dirty` and preserves edit
  state; entries-saved sweep behaves correctly in both cases.
- End-to-end race reproduction: snapshot → type credentials → sync
  completes → file stays `modified`/`dirty` and entry stays `unsaved`.
- Regression check: clean sync (no concurrent edits) still clears state.

All 10 tests fail on master and pass with this fix. Full suite: 94
passing.